### PR TITLE
Bug: fix Angular 2 bootstrap import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Augury is a Google Chrome Dev Tools extension for debugging Angular 2 applicatio
 
 ## Supported Version
 
-Currently works with applications built in [Angular 2.0.0-beta.14](https://github.com/angular/angular/blob/master/CHANGELOG.md#200-beta14-2016-04-07) with _limited backwards compatibility_, which will change once Angular 2 stabilizes.
+Currently works with applications built in [Angular 2.0.0-beta.15](https://github.com/angular/angular/blob/master/CHANGELOG.md#200-beta15-2016-04-13) with _limited backwards compatibility_, which will change once Angular 2 stabilizes.
 
 ## Join Our Slack Team
 

--- a/package.json
+++ b/package.json
@@ -31,19 +31,19 @@
     "pack": "./crxmake.sh"
   },
   "dependencies": {
-    "angular2": "^2.0.0-beta.14",
+    "angular2": "^2.0.0-beta.15",
     "basscss": "^7.0.4",
     "core-js": "^2.2.2",
     "crypto": "0.0.3",
     "d3": "^3.5.16",
-    "es6-promise": "^3.0.2",
+    "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",
     "file-loader": "^0.8.5",
     "immutable": "^3.7.6",
     "json-formatter-js": "^0.3.0",
-    "reflect-metadata": "0.1.3",
+    "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",
-    "zone.js": "0.6.8"
+    "zone.js": "0.6.10"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -1,5 +1,5 @@
 import {Component, Inject, bind, NgZone} from 'angular2/core';
-import {bootstrap} from 'angular2/bootstrap';
+import {bootstrap} from 'angular2/platform/browser';
 
 import {Dispatcher} from './dispatcher/dispatcher';
 


### PR DESCRIPTION
Fixes import of the `bootstrap` function which is exported by `angular2/platform/browser` now and not from `angular2/bootstrap`. Otherwise the project doesn't compile.