### PR TITLE
Avoid auto compile and build TS on saving file changes for editors like VIM, Atom, etc.

### DIFF
--- a/example-apps/ami-superhero/e2e/tsconfig.json
+++ b/example-apps/ami-superhero/e2e/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compileOnSave": false,
+  "buildOnSave": false,
   "compilerOptions": {
     "declaration": false,
     "emitDecoratorMetadata": true,

--- a/example-apps/ami-superhero/src/client/tsconfig.json
+++ b/example-apps/ami-superhero/src/client/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compileOnSave": false,
+  "buildOnSave": false,
   "compilerOptions": {
     "declaration": false,
     "emitDecoratorMetadata": true,

--- a/example-apps/kitchen-sink-example/tsconfig.json
+++ b/example-apps/kitchen-sink-example/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "compileOnSave": false,
+  "buildOnSave": false,
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",

--- a/example-apps/todo-mvc-example/tsconfig.json
+++ b/example-apps/todo-mvc-example/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  "compileOnSave": false,
+  "buildOnSave": false,
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "version": "1.6.2",
+  "compileOnSave": false,
+  "buildOnSave": false,
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",


### PR DESCRIPTION
When using Atom or VIM, every time a `.ts` file is changed it triggers auto compile and build. This causes generating `.js` and `.js.map` of the modified `.ts` file, which is very counter productive.