### PR TITLE
Add license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,6 @@
     "url-loader": "^0.5.7",
     "webpack": "1.13.0",
     "webpack-dev-server": "1.14.1"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
To remove the following warning which appears when running `npm install`:
`npm WARN augury@1.0.0 No license field.`