### PR TITLE
Allow background color to span full width upon hover

### DIFF
--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -12,4 +12,4 @@
 @import './base.css';
 @import './components/components.css';
 @import './properties.css';
-@import './utils/utils.css';
+@import './utils/utils.css'; 

--- a/src/styles/components/node-items.css
+++ b/src/styles/components/node-items.css
@@ -3,10 +3,11 @@
 
 .node-item {
   cursor: pointer;
-  width: 100%;
 
   &:hover {
     background-color: var(--blue-light);
+    padding-left: 58px;
+    margin-left: -50px;
   }
 }
 
@@ -17,6 +18,8 @@
 .node-item-selected,
 .node-item-selected:hover {
   background-color: var(--blue);
+  padding-left: 58px !important;
+  margin-left: -50px;
 }
 
 .node-item-name {


### PR DESCRIPTION
This PR allows for the background color to span the entire width of the container. Prior it stopped at the beginning of each line.

Preview Below:

![screen shot 2016-05-16 at 12 19 47 pm](https://cloud.githubusercontent.com/assets/11047559/15295984/47b67988-1b61-11e6-8005-02838050945d.png)
