### PR TITLE
Don't add null dependencies non existing names

### DIFF
--- a/src/backend/adapters/angular2.ts
+++ b/src/backend/adapters/angular2.ts
@@ -233,7 +233,11 @@ export class Angular2Adapter extends BaseAdapter {
       const parameters = Reflect.getOwnMetadata
         ('design:paramtypes', debugEl.componentInstance.constructor) || [];
 
-      parameters.forEach((param) => dependencies.push(param.name));
+      parameters.forEach((param) => {
+        if (param) {
+          dependencies.push(param.name);
+        }
+      });
     }
 
     return dependencies;


### PR DESCRIPTION
In case of optionnal dependencies, the `param` value can be null.
Thus, there is no `name` property and the following error is thrown :
`Uncaught TypeError: Cannot read property 'name' of undefined`