### PR TITLE
chore: rename openedNodes to closedNodes

### DIFF
--- a/src/frontend/actions/user-actions/user-actions.ts
+++ b/src/frontend/actions/user-actions/user-actions.ts
@@ -87,13 +87,13 @@ export class UserActions {
    * Update the node state after re rendering the tree.
    * Select the previously selected node and
    * Preserve state of previously Closed Component.
-   * @param  {Object} options.openedNodes list of opened Nodes id's
+   * @param  {Object} options.closedNodes list of closed Nodes id's
    * @param  {Object} options.selectedNode currently selectedNode
    */
-  updateNodeState({openedNodes, selectedNode}) {
+  updateNodeState({closedNodes, selectedNode}) {
     this.dispatcher.messageBus.next({
       actionType: UserActionType.UPDATE_NODE_STATE,
-      openedNodes,
+      closedNodes,
       selectedNode
     });
   }

--- a/src/frontend/components/app-trees/app-trees.html
+++ b/src/frontend/components/app-trees/app-trees.html
@@ -9,7 +9,7 @@
   [ngClass]="{flex: selectedTabIndex == 0}"
   [changedNodes]="changedNodes"
   [selectedNode]="selectedNode"
-  [openedNodes]="openedNodes"
+  [closedNodes]="closedNodes"
   [tree]="tree">
   </bt-tree-view>
 

--- a/src/frontend/components/app-trees/app-trees.ts
+++ b/src/frontend/components/app-trees/app-trees.ts
@@ -9,7 +9,7 @@ import {RouterTree} from '../router-tree/router-tree';
   selector: 'bt-app-trees',
   directives: [TabMenu, TreeView, RouterTree],
   inputs: ['tree', 'routerTree', 'selectedTabIndex',
-    'selectedNode', 'changedNodes', 'openedNodes'],
+    'selectedNode', 'changedNodes', 'closedNodes'],
   templateUrl:
     '/src/frontend/components/app-trees/app-trees.html'
 })

--- a/src/frontend/components/component-tree/component-tree.html
+++ b/src/frontend/components/component-tree/component-tree.html
@@ -4,6 +4,6 @@
     [changedNodes]="changedNodes"
     [node]="node"
     [selectedNode]="selectedNode"
-    [openedNodes]="openedNodes">
+    [closedNodes]="closedNodes">
     </bt-node-item>
 </main>

--- a/src/frontend/components/component-tree/component-tree.ts
+++ b/src/frontend/components/component-tree/component-tree.ts
@@ -6,7 +6,7 @@ import {UserActionType}
 
 @Component({
   selector: 'component-tree',
-  inputs: ['tree', 'changedNodes', 'selectedNode', 'openedNodes'],
+  inputs: ['tree', 'changedNodes', 'selectedNode', 'closedNodes'],
   templateUrl: 'src/frontend/components/component-tree/component-tree.html',
   host: {'class': 'flex overflow-scroll'},
   directives: [NgFor, NodeItem]

--- a/src/frontend/components/node-item/node-item.ts
+++ b/src/frontend/components/node-item/node-item.ts
@@ -36,7 +36,7 @@ import {UserActionType}
           [changedNodes]="changedNodes"
           [hidden]="showChildren()"
           [selectedNode]="selectedNode"
-          [openedNodes]="openedNodes"
+          [closedNodes]="closedNodes"
           [node]="node">
         </bt-node-item>
       </div>
@@ -53,7 +53,7 @@ export class NodeItem {
   @Input() node: any;
   @Input() changedNodes: any;
   @Input() selectedNode: any;
-  @Input() openedNodes: Array<any>;
+  @Input() closedNodes: Array<any>;
 
   private collapsed: any;
   private isUpdated: boolean = false;
@@ -161,8 +161,8 @@ export class NodeItem {
         this.isUpdated = false;
       }, 2000);
     }
-    if (this.openedNodes && this.node) {
-      if (this.openedNodes.indexOf(this.node.id) > -1) {
+    if (this.closedNodes && this.node) {
+      if (this.closedNodes.indexOf(this.node.id) > -1) {
         this.node.isOpen = false;
       }
     }

--- a/src/frontend/components/tree-view/tree-view.html
+++ b/src/frontend/components/tree-view/tree-view.html
@@ -3,6 +3,6 @@
     [changedNodes]="changedNodes"
     [tree]="tree"
     [selectedNode]="selectedNode"
-    [openedNodes]="openedNodes">
+    [closedNodes]="closedNodes">
     </component-tree>
 </div>

--- a/src/frontend/components/tree-view/tree-view.ts
+++ b/src/frontend/components/tree-view/tree-view.ts
@@ -10,7 +10,7 @@ import {ComponentTree} from '../component-tree/component-tree';
 
 @Component({
   selector: 'bt-tree-view',
-  inputs: ['tree', 'changedNodes', 'selectedNode', 'openedNodes'],
+  inputs: ['tree', 'changedNodes', 'selectedNode', 'closedNodes'],
   templateUrl: 'src/frontend/components/tree-view/tree-view.html',
   directives: [NgFor, NodeItem, ComponentTree]
 })

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -46,7 +46,7 @@ const BASE_STYLES = require('!style!css!postcss!../styles/app.css');
             class="flex flex-column flex-auto bg-white"
             [selectedTabIndex]="selectedTabIndex"
             [selectedNode]="selectedNode"
-            [openedNodes]="openedNodes"
+            [closedNodes]="closedNodes"
             [routerTree]="routerTree"
             [tree]="tree"
             [theme]="theme"
@@ -77,7 +77,7 @@ class App {
   private routerTree: any;
   private selectedTabIndex = 0;
   private selectedNode: any;
-  private openedNodes: Array<any> = [];
+  private closedNodes: Array<any> = [];
   private changedNodes: any = [];
   private searchDisabled: boolean = false;
   private theme: string;
@@ -117,7 +117,7 @@ class App {
           const treeMapNode = treeMap[data.selectedNode.id];
           this.selectedNode = treeMapNode ? JSON.parse(treeMapNode) : undefined;
         }
-        this.openedNodes = data.openedNodes;
+        this.closedNodes = data.closedNodes;
         this._ngZone.run(() => undefined);
       }
     );

--- a/src/frontend/stores/component-data/component-data-store.test.ts
+++ b/src/frontend/stores/component-data/component-data-store.test.ts
@@ -29,7 +29,7 @@ test('frontend/component-data-store: component changes', t => {
     t.deepEqual(data, {
       action: 'START_COMPONENT_TREE_INSPECTION',
       componentData: mockData,
-      openedNodes: [],
+      closedNodes: [],
       selectedNode: undefined
     }, 'emits component tree change event');
   });

--- a/src/frontend/stores/component-data/component-data-store.ts
+++ b/src/frontend/stores/component-data/component-data-store.ts
@@ -19,7 +19,7 @@ interface SearchCriteria {
 export class ComponentDataStore extends AbstractStore {
 
   private _componentData;
-  private _openedNodes = [];
+  private _closedNodes = [];
   private _selectedNode;
 
   constructor(
@@ -83,7 +83,7 @@ export class ComponentDataStore extends AbstractStore {
     this.emitChange({
       componentData,
       selectedNode: this._selectedNode,
-      openedNodes: this._openedNodes,
+      closedNodes: this._closedNodes,
       action: UserActionType.START_COMPONENT_TREE_INSPECTION
     });
   }
@@ -128,24 +128,24 @@ export class ComponentDataStore extends AbstractStore {
   }
 
   /**
-   * Update node state of current openedNodes and selectedNode
-   * @param  {Object} openedNodes Currently closed Nodes
+   * Update node state of current closedNodes and selectedNode
+   * @param  {Object} closedNodes Currently closed Nodes
    * @param  {Object} selectedNode Current selected Node
    */
-  private updateNodeState({openedNodes, selectedNode}) {
+  private updateNodeState({closedNodes, selectedNode}) {
     selectedNode = this.getUpdatedNode(selectedNode);
     this.emitChange({
-      openedNodes,
+      closedNodes,
       selectedNode,
       action: UserActionType.OPEN_CLOSE_TREE
     });
   }
 
   /**
-   * Clear the selection of previously selectedNode and openedNodes
+   * Clear the selection of previously selectedNode and closedNodes
    */
   private clearSelections() {
-    this._openedNodes = [];
+    this._closedNodes = [];
     this._selectedNode = undefined;
   }
 
@@ -251,15 +251,15 @@ export class ComponentDataStore extends AbstractStore {
   }
 
   /**
-   * Save the node id to openedNodes array on clicking expand and collapse
+   * Save the node id to closedNodes array on clicking expand and collapse
    */
   private openCloseNode({node}) {
-    const index = this._openedNodes.indexOf(node.id);
+    const index = this._closedNodes.indexOf(node.id);
     if (!node.isOpen && index === -1) {
-      this._openedNodes.push(node.id);
+      this._closedNodes.push(node.id);
     } else if (node.isOpen) {
       if (index > -1) {
-        this._openedNodes.splice(index, 1);
+        this._closedNodes.splice(index, 1);
       }
     }
   }


### PR DESCRIPTION
### Changes
* Rename `openedNodes` to `closedNodes`

### Closes
* https://github.com/rangle/augury/issues/363

### Notes
* I used WebStorm to tell me all exact instances of `openedNodes`, and on a one-by-one basis used my best judgement to convert from one variable name to another.
* Use the build from below to test it manually, it seems to work with the [demo](https://augury.angular.io/demo/).


### Build
* ~~[augury.zip](https://github.com/rangle/augury/files/330791/augury.zip)~~ (1)
* [augury.zip](https://github.com/rangle/augury/files/330807/augury.zip) (2)

