### PR TITLE
Add binding property name whenever given `@Input('<some custom name>')`

### DIFF
--- a/example-apps/kitchen-sink-new-router/source/components/metadata-test/metadata-test.ts
+++ b/example-apps/kitchen-sink-new-router/source/components/metadata-test/metadata-test.ts
@@ -17,12 +17,41 @@ export class MetadataFromDecorator {
     @Input() attrIn: any;
     @Output() attrOut: any;
 }
+
+
+@Component({
+    selector: "attr-from-array-custom",
+    inputs: ["attrIn:attrCustomIn"],
+    outputs: ["attrOut"],
+    template: `<p>{{attrIn}}</p>`
+})
+export class MetadataFromArrayWithCustomName {
+}
+
+@Component({
+    selector: "attr-from-decorator-custom",
+    template: `<p>{{attrIn}}</p>`
+})
+export class MetadataFromDecoratorWithCustomName {
+    @Input("attrCustomIn") attrIn: any;
+    @Output() attrOut: any;
+}
+
+
 @Component({
   selector: 'metadata-test',
-  directives: [MetadataFromArray, MetadataFromDecorator],
+  directives: [
+    MetadataFromArray, 
+    MetadataFromDecorator, 
+    MetadataFromArrayWithCustomName, 
+    MetadataFromDecoratorWithCustomName
+  ],
   template: `
     <attr-from-array attrIn="Data from the array."></attr-from-array>
     <attr-from-decorator attrIn="Data from the decorator."></attr-from-decorator>
+
+    <attr-from-array-custom attrCustomIn="Data from array using a custom name"></attr-from-array-custom>
+    <attr-from-decorator-custom attrCustomIn="Data from decorator using a custom name"></attr-from-decorator-custom>
   `
 })
 export default class MetadataTest {

--- a/example-apps/kitchen-sink-new-router/source/components/metadata-test/metadata-test.ts
+++ b/example-apps/kitchen-sink-new-router/source/components/metadata-test/metadata-test.ts
@@ -1,0 +1,30 @@
+import {Component, Input, Output} from '@angular/core';
+
+@Component({
+    selector: "attr-from-array",
+    inputs: ["attrIn"],
+    outputs: ["attrOut"],
+    template: `<p>{{attrIn}}</p>`
+})
+export class MetadataFromArray {
+}
+
+@Component({
+    selector: "attr-from-decorator",
+    template: `<p>{{attrIn}}</p>`
+})
+export class MetadataFromDecorator {
+    @Input() attrIn: any;
+    @Output() attrOut: any;
+}
+@Component({
+  selector: 'metadata-test',
+  directives: [MetadataFromArray, MetadataFromDecorator],
+  template: `
+    <attr-from-array attrIn="Data from the array."></attr-from-array>
+    <attr-from-decorator attrIn="Data from the decorator."></attr-from-decorator>
+  `
+})
+export default class MetadataTest {
+}
+

--- a/example-apps/kitchen-sink-new-router/source/components/metadata-test/metadata-test.ts
+++ b/example-apps/kitchen-sink-new-router/source/components/metadata-test/metadata-test.ts
@@ -1,16 +1,16 @@
 import {Component, Input, Output} from '@angular/core';
 
 @Component({
-    selector: "attr-from-array",
-    inputs: ["attrIn"],
-    outputs: ["attrOut"],
+    selector: 'attr-from-array',
+    inputs: ['attrIn'],
+    outputs: ['attrOut'],
     template: `<p>{{attrIn}}</p>`
 })
 export class MetadataFromArray {
 }
 
 @Component({
-    selector: "attr-from-decorator",
+    selector: 'attr-from-decorator',
     template: `<p>{{attrIn}}</p>`
 })
 export class MetadataFromDecorator {
@@ -20,20 +20,20 @@ export class MetadataFromDecorator {
 
 
 @Component({
-    selector: "attr-from-array-custom",
-    inputs: ["attrIn:attrCustomIn"],
-    outputs: ["attrOut"],
+    selector: 'attr-from-array-custom',
+    inputs: ['attrIn:attrCustomIn'],
+    outputs: ['attrOut'],
     template: `<p>{{attrIn}}</p>`
 })
 export class MetadataFromArrayWithCustomName {
 }
 
 @Component({
-    selector: "attr-from-decorator-custom",
+    selector: 'attr-from-decorator-custom',
     template: `<p>{{attrIn}}</p>`
 })
 export class MetadataFromDecoratorWithCustomName {
-    @Input("attrCustomIn") attrIn: any;
+    @Input('attrCustomIn') attrIn: any;
     @Output() attrOut: any;
 }
 
@@ -41,17 +41,23 @@ export class MetadataFromDecoratorWithCustomName {
 @Component({
   selector: 'metadata-test',
   directives: [
-    MetadataFromArray, 
-    MetadataFromDecorator, 
-    MetadataFromArrayWithCustomName, 
+    MetadataFromArray,
+    MetadataFromDecorator,
+    MetadataFromArrayWithCustomName,
     MetadataFromDecoratorWithCustomName
   ],
   template: `
-    <attr-from-array attrIn="Data from the array."></attr-from-array>
-    <attr-from-decorator attrIn="Data from the decorator."></attr-from-decorator>
+    <attr-from-array attrIn='Data from the array.'>
+    </attr-from-array>
 
-    <attr-from-array-custom attrCustomIn="Data from array using a custom name"></attr-from-array-custom>
-    <attr-from-decorator-custom attrCustomIn="Data from decorator using a custom name"></attr-from-decorator-custom>
+    <attr-from-decorator attrIn='Data from the decorator.'>
+    </attr-from-decorator>
+
+    <attr-from-array-custom attrCustomIn='Data from array using a custom name.'>
+    </attr-from-array-custom>
+
+    <attr-from-decorator-custom attrCustomIn='Data from decorator using a custom name.'>
+    </attr-from-decorator-custom>
   `
 })
 export default class MetadataTest {

--- a/example-apps/kitchen-sink-new-router/source/containers/kitchen-sink.ts
+++ b/example-apps/kitchen-sink-new-router/source/containers/kitchen-sink.ts
@@ -26,6 +26,7 @@ import InnerChild from '../components/router/inner-child';
 import RouterData1 from '../components/router/router-data1';
 import RouterData2 from '../components/router/router-data2';
 import AuxComp from '../components/router/aux-comp';
+import MetadataTest from '../components/metadata-test/metadata-test';
 
 export const KitchenSinkRoutes: RouterConfig = [
   { path: '', component: Home },
@@ -46,7 +47,8 @@ export const KitchenSinkRoutes: RouterConfig = [
     { path: 'child', component: StartChild },
     { path: 'router-data1/:name', component: RouterData1 },
     { path: 'router-data2/:name/:message', component: RouterData2 }]
-  }
+  },
+  { path: 'metadata-test', component: MetadataTest },
 ];
 
 @Component({
@@ -95,6 +97,9 @@ export const KitchenSinkRoutes: RouterConfig = [
       </li>
       <li [ngClass]="{active: path=='stress-tester'}">
         <a [routerLink]="['./stress-tester']">StressTester</a>
+      </li>
+      <li [ngClass]="{active: path=='metadata-test'}">
+        <a [routerLink]="['./metadata-test']">MetadataTest</a>
       </li>
       </ul>
     </div>

--- a/src/backend/adapters/angular2.ts
+++ b/src/backend/adapters/angular2.ts
@@ -335,7 +335,11 @@ export class Angular2Adapter extends BaseAdapter {
           for (const meta of propMetadata[key]) {
             if (meta.constructor.name === (InputMetadata as any).name) {
               if (inputs.indexOf(key) < 0) { // avoid duplicates
-                inputs.push(key);
+                if (meta.bindingPropertyName) {
+                  inputs.push(`${key}:${meta.bindingPropertyName}`);
+                } else {
+                  inputs.push(key);
+                }
               }
             }
           }


### PR DESCRIPTION
#### Changes
* Add binding property name whenever given `@Input('<some custom name>')`
* Add example section called MetadataTest, this section tests for inputs and outputs on the `@Component{ ... }` and `@Input/@Output`