### PR TITLE
chore: build augury, create crx file, and move it to the artifacts folder in circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,8 @@ machine:
 dependencies:
   pre:
     - rm -rf node_modules typings
+  post:
+    - npm run build; ./crxmake.sh
 
 test:
   pre:

--- a/crxmake.sh
+++ b/crxmake.sh
@@ -13,13 +13,16 @@ name="augury"
 files="manifest.json build src images index.html frontend.html popup.html"
 
 crx="$name.crx"
-if [ $CIRCLE_BUILD_NUM ]; then
-  crx="$name-$CIRCLE_BUILD_NUM.crx"
-fi
-
 pub="$name.pub"
 sig="$name.sig"
 zip="$name.zip"
+
+# assign build name to zip and crx file in circleci env
+if [ $CIRCLE_BUILD_NUM ] || [ $CIRCLE_ARTIFACTS ]; then
+  crx="$name-$CIRCLE_BUILD_NUM.crx"
+  zip="$name-$CIRCLE_BUILD_NUM.zip"
+fi
+
 trap 'rm -f "$pub" "$sig"' EXIT
 
 # copy all the files we need
@@ -58,6 +61,13 @@ sig_len_hex=$(byte_swap $(printf '%08x\n' $(ls -l "$sig" | awk '{print $5}')))
 ) > "$crx"
 
 echo "Wrote $crx"
+
+# move crx to artifacts folder in circleci
+if [ $CIRCLE_ARTIFACTS ]; then
+  mv $crx $CIRCLE_ARTIFACTS
+  mv $zip $CIRCLE_ARTIFACTS
+fi
+
 
 echo "<script>window.location.href = 'https://s3.amazonaws.com/batarangle.io/$crx';</script>" > download.html
 echo "Wrote file"


### PR DESCRIPTION
#### Changes
* Build the crx and zip file for Augury and place it in the Artifacts folder in CircleCI
* The uploaded files are viewed within CircleCI under the Artifacts tab. https://circleci.com/gh/rangle/augury/908#artifacts (this is the build for this PR)
