### PR TITLE
Fixes #487 - exclude option elements from getting augury id

### DIFF
--- a/src/backend/adapters/angular2.ts
+++ b/src/backend/adapters/angular2.ts
@@ -102,8 +102,8 @@ export class Angular2Adapter extends BaseAdapter {
     if (compEl.children.length > 0) {
       compEl
       .children
+      .filter((child: any) => !this._isComponentExcluded(child))
       .forEach((child: any, childIdx: number) => {
-
         let index: string = idx;
         if (child.providerTokens.length > 0) {
           index = [idx, this._tree[idx]].join('.');
@@ -174,7 +174,6 @@ export class Angular2Adapter extends BaseAdapter {
   _emitNativeElement = (compEl: any, isRoot: boolean,
     idx: string): void => {
     const nativeElement = this._getNativeElement(compEl);
-    const nodeName = this._getComponentName(compEl);
 
     // When encounter a template comment, insert another comment with
     // augury-id above it.
@@ -187,12 +186,9 @@ export class Angular2Adapter extends BaseAdapter {
     } else {
       (<HTMLElement>nativeElement).setAttribute('augury-id', idx);
     }
-
     if (isRoot) {
       return this.addRoot(compEl);
-    } else if (nodeName !== 'option') {
-      // skipping the option to improve performance 
-      // It adds no value displaying node elements
+    } else {
       this.addChild(compEl);
     }
   };
@@ -297,6 +293,12 @@ export class Angular2Adapter extends BaseAdapter {
     }
 
     return true;
+  }
+
+  _isComponentExcluded(debugEl: any): boolean {
+    // skipping the option to improve performance
+    // It adds no value displaying node elements
+    return this._getComponentName(debugEl) === 'option';
   }
 
   _getComponentState(debugEl: any): Object {


### PR DESCRIPTION
Option elements are excluded from being added to the compoment tree.

However, we must also exclude them from being numbered when assigning
augury-id's.

Otherwise, if we have option elements with other elements after it, we
will get undefined elements in the parent component's child array in the
component tree, since it assigns to the child array using the augury-id
as an index to the array.

Example:
If we have 4 `<option>` elements with a `<div>` after it, then the four
`<option>` elements have augury-id 0 to 3 and the `<div>` would get id 4.

When adding to the child array of the parent, the four `<option>`
elements are not added. The `<div>` after is added, but is added to index
4 in the child array. This creates undefined elements in positions 0-3 in
the array.

The front-end is then given the component tree and a JS error is thrown
when the user highlights the null node.