### PR TITLE
fixes #504 - Add trackBy functions to ngFor in component tree

### DIFF
--- a/src/frontend/components/component-tree/component-tree.html
+++ b/src/frontend/components/component-tree/component-tree.html
@@ -1,6 +1,6 @@
 <!-- BLOCK VIEW -->
 <main class="monospace col-12 p1">
-  <bt-node-item *ngFor="let node of tree"
+  <bt-node-item *ngFor="let node of tree; trackBy: trackById"
     [changedNodes]="changedNodes"
     [node]="node"
     [selectedNode]="selectedNode"

--- a/src/frontend/components/component-tree/component-tree.ts
+++ b/src/frontend/components/component-tree/component-tree.ts
@@ -45,4 +45,7 @@ export class ComponentTree {
     }
   }
 
+  trackById(index: number, node: any): string {
+    return node.id;
+  }
 }

--- a/src/frontend/components/node-item/node-item.ts
+++ b/src/frontend/components/node-item/node-item.ts
@@ -29,7 +29,7 @@ import {UserActions} from '../../actions/user-actions/user-actions';
       </div>
     
       <div class="border-box pl4" *ngIf="node.isOpen || wasRendered">
-        <bt-node-item *ngFor="let node of node.children"
+        <bt-node-item *ngFor="let node of node.children; trackBy: trackById"
           [changedNodes]="changedNodes"
           [hidden]="showChildren()"
           [selectedNode]="selectedNode"
@@ -189,5 +189,9 @@ export class NodeItem {
         this.node.isOpen = false;
       }
     }
+  }
+
+  trackById(index: number, node: any): string {
+    return node.id;
   }
 }


### PR DESCRIPTION
Add trackBy functions to ngFor in component tree, using the unique
id field for each node.

This should improve performance when adding or removing nodes.