### PR TITLE
fixes #496

### DIFF
--- a/src/frontend/components/node-item/node-item.ts
+++ b/src/frontend/components/node-item/node-item.ts
@@ -81,7 +81,7 @@ export class NodeItem {
   // Return true if the component tree should no longer be opening
   // its nodes by default, if false keep expanding the tree.
   isDepthLimitReached(): boolean {
-    return this.allowedComponentTreeDepth <= 0;
+    return this.allowedComponentTreeDepth <= 0 && !this.node.overrideDepthLimit;
   }
 
   getNodeDetails(node) {

--- a/src/frontend/stores/component-data/component-data-store.test.ts
+++ b/src/frontend/stores/component-data/component-data-store.test.ts
@@ -56,10 +56,27 @@ test('frontend/component-data-store: user selects tree node', t => {
     id: '0.0',
     name: 'INPUT'
   };
+  const mockTree = [{
+    name: 'TodoList',
+    children: [{
+      id: '0.0',
+      name: 'INPUT'
+    }, {
+      id: '0.1',
+      name: 'NgIf'
+    }]
+  }];
 
-  componentStore.dataStream.subscribe((data: any) => {
-    t.deepEqual(data.selectedNode, mockData,
-      'emits user selects node event');
+  componentStore.dataStream
+    .filter((data: any) => data.selectedNode)
+    .subscribe((data: any) => {
+      t.deepEqual(data.selectedNode, mockData,
+        'emits user selects node event');
+    });
+
+  mockDispatcher.messageBus.next({
+    actionType: BackendActionType.COMPONENT_TREE_CHANGED,
+    componentData: mockTree
   });
 
   mockDispatcher.messageBus.next({
@@ -104,7 +121,8 @@ test('frontend/component-data-store: user searches for node', t => {
 
   mockDispatcher.messageBus.next({
     actionType: UserActionType.SEARCH_NODE,
-    query: mockQuery
+    query: mockQuery,
+    index: 0
   });
 
   t.end();

--- a/src/frontend/stores/component-data/component-data-store.ts
+++ b/src/frontend/stores/component-data/component-data-store.ts
@@ -97,6 +97,45 @@ export class ComponentDataStore extends AbstractStore {
   }
 
   /**
+   * Get the nodes from root of the tree to given node.
+   * @param  {Object} node
+   */
+  private getPathToNode(node: any): any[] {
+    // The ID shows the path from root to given node.
+    let splitId: number[] = node.id.split('.');
+    let nodes: any[] = [];
+
+    // First index is for the component root:
+    let rootIndex = splitId.shift();
+    let root = this._componentData[rootIndex];
+    nodes.push(root);
+
+    // Next traverse the tree by index from ID.
+    splitId.reduce((previousNode: any, childIndex: number) => {
+      let child = previousNode.children[childIndex];
+      nodes.push(child);
+      return child;
+    }, root);
+    return nodes;
+  }
+
+  /**
+   * Opens the nodes from root of the tree to given node
+   * to reveal the given node.
+   * @param  {Object} node
+   */
+  private openPathToNode(node: any) {
+    let path = this.getPathToNode(node);
+    path.pop(); // Only open until the parent of selected.
+
+    path.forEach(pathNode => {
+      pathNode.isOpen = true;
+      pathNode.overrideDepthLimit = true;
+      this.openCloseNode({ node: pathNode });
+    });
+  }
+
+  /**
    * Select a node to be highlighted after search
    * @param  {Object} node Current selected Node
    * @param  {number} searchIndex Current search Index
@@ -105,6 +144,9 @@ export class ComponentDataStore extends AbstractStore {
   private selectNode(node: any, searchIndex: number = -1,
                      totalSearchCount: number = 0) {
     this._selectedNode = node;
+    if (node) {
+      this.openPathToNode(node);
+    }
     this.emitChange({
       selectedNode: this._selectedNode,
       searchIndex: searchIndex,


### PR DESCRIPTION
When selecting node, open component tree from root to the selected
node so that nodes are revealed when the user searches for them.