### PR TITLE
fixes #517 - Run theme change in an Angular zone since the chrome

### DIFF
--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -85,11 +85,14 @@ class App {
     private parseUtils: ParseUtils
   ) {
     chrome.storage.sync.get('theme', (result: any) => {
-      if (result.theme === 'dark') {
-        this.theme = result.theme;
-      } else {
-        this.theme = 'light'; // default theme
-      }
+      // Run in Angular zone so that theme change is detected.
+      this._ngZone.run(() => {
+        if (result.theme === 'dark') {
+          this.theme = result.theme;
+        } else {
+          this.theme = 'light'; // default theme
+        }
+      });
     });
 
     this.userActions.startComponentTreeInspection();


### PR DESCRIPTION
storage sync function seems to happen outside the zone and
Angular needs to update the view after the theme loads.

This caused an issue where the dark theme would not render until
the component tree load caused a view update.