### PR TITLE
Implement resizable SplitPane component

### DIFF
--- a/src/frontend/components/app-trees/app-trees.html
+++ b/src/frontend/components/app-trees/app-trees.html
@@ -1,21 +1,39 @@
 <bt-tab-menu
-  [tabs]="tabs"
-  (tabChange)="tabClicked($event)"
-  [selectedTabIndex]="selectedTabIndex">
-  </bt-tab-menu>
+   [tabs]="tabs"
+   (tabChange)="tabClicked($event)"
+   [selectedTabIndex]="selectedTabIndex">
+</bt-tab-menu>
 
-<bt-tree-view
-  [hidden]="selectedTabIndex != 0"
-  [ngClass]="{flex: selectedTabIndex == 0}"
-  [changedNodes]="changedNodes"
-  [selectedNode]="selectedNode"
-  [closedNodes]="closedNodes"
-  [tree]="tree"
-  [allowedComponentTreeDepth]="allowedComponentTreeDepth">
-  </bt-tree-view>
+<split-pane class="flex flex-auto">
+  <split-pane-primary-content
+     class="flex flex-column flex-auto"
+     [ngClass]="{'overflow-scroll': selectedTabIndex > 0}">
+    <bt-tree-view
+       [hidden]="selectedTabIndex != 0"
+       [ngClass]="{flex: selectedTabIndex == 0}"
+       [changedNodes]="changedNodes"
+       [selectedNode]="selectedNode"
+       [closedNodes]="closedNodes"
+       [tree]="tree"
+       [allowedComponentTreeDepth]="allowedComponentTreeDepth">
+    </bt-tree-view>
+  </split-pane-primary-content>
+  <split-pane-secondary-content
+     class="flex flex-column flex-auto"
+     [ngClass]="{'flex': selectedTabIndex === 0}"
+     [hidden]="selectedTabIndex > 0">
+    <bt-info-panel
+       class="flex flex-column flex-auto bg-white"
+       [tree]="tree"
+       [theme]="theme"
+       [node]="selectedNode">
+    </bt-info-panel>
+  </split-pane-secondary-content>
+</split-pane>
 
-<bt-router-tree class="overflow-scroll flex-auto"
-  [theme]="theme"
-  [hidden]="selectedTabIndex != 1"
-  [routerTree]="routerTree">
-  </bt-router-tree>
+<bt-router-tree
+   class="overflow-scroll flex-auto"
+   [theme]="theme"
+   [hidden]="selectedTabIndex != 1"
+   [routerTree]="routerTree">
+</bt-router-tree>

--- a/src/frontend/components/split-pane/split-pane.html
+++ b/src/frontend/components/split-pane/split-pane.html
@@ -18,8 +18,6 @@
      style="width: 6px; top: 0; bottom: 0; margin-right: -3px; cursor: ew-resize; z-index: 500; position: absolute;">
   </div>
   <div
-     #movecapture
-     (mousemove)="moveCaptureMouseMove($event)"
-     (mouseup)="moveCaptureMouseUp()"
+     #overlay
      style="z-index: 5000; position: absolute; cursor: ew-resize; top: 0; left: 0; right: 0; bottom: 0; display: none;"></div>
 </div>

--- a/src/frontend/components/split-pane/split-pane.html
+++ b/src/frontend/components/split-pane/split-pane.html
@@ -12,11 +12,13 @@
      class="col overflow-hidden flex mh100pct">
     <ng-content select="split-pane-secondary-content"></ng-content>
   </div>
+  <!-- These style properties are inline because they define the behaviour of the resizer bar, which is invisible. -->
   <div
      #resizer
      (mousedown)="resizerMouseDown($event)"
      style="width: 6px; top: 0; bottom: 0; margin-right: -3px; cursor: ew-resize; z-index: 500; position: absolute;">
   </div>
+  <!-- These style properties are inline because they define the behaviour of the overlay, which is invisible. -->
   <div
      #overlay
      style="z-index: 5000; position: absolute; cursor: ew-resize; top: 0; left: 0; right: 0; bottom: 0; display: none;"></div>

--- a/src/frontend/components/split-pane/split-pane.html
+++ b/src/frontend/components/split-pane/split-pane.html
@@ -1,0 +1,25 @@
+<div
+   #wrapper
+   (window:resize)="windowResized()"
+   class="flex flex-auto">
+  <div
+     #primary
+     class="col overflow-hidden flex mh100pct">
+    <ng-content select="split-pane-primary-content"></ng-content>
+  </div>
+  <div
+     #secondary
+     class="col overflow-hidden flex mh100pct">
+    <ng-content select="split-pane-secondary-content"></ng-content>
+  </div>
+  <div
+     #resizer
+     (mousedown)="resizerMouseDown($event)"
+     style="width: 6px; top: 0; bottom: 0; margin-right: -3px; cursor: ew-resize; z-index: 500; position: absolute;">
+  </div>
+  <div
+     #movecapture
+     (mousemove)="moveCaptureMouseMove($event)"
+     (mouseup)="moveCaptureMouseUp()"
+     style="z-index: 5000; position: absolute; cursor: ew-resize; top: 0; left: 0; right: 0; bottom: 0; display: none;"></div>
+</div>

--- a/src/frontend/components/split-pane/split-pane.ts
+++ b/src/frontend/components/split-pane/split-pane.ts
@@ -1,0 +1,120 @@
+/**
+ * <split-pane> component.
+ *
+ * This may seem like a mess, but there is no other way to implement resizable panes.
+ */
+
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+} from '@angular/core';
+
+// This value matches the behaviour in the Chrome Dev Tools
+const MIN_PANE_WIDTH = 26;
+
+const DEFAULT_SECONDARY_WIDTH = 384;
+
+@Component({
+  selector: 'split-pane',
+  templateUrl: '/src/frontend/components/split-pane/split-pane.html'
+})
+export default class SplitPane {
+  @ViewChild('wrapper') wrapperElement : ElementRef;
+  @ViewChild('resizer') resizerElement : ElementRef;
+  @ViewChild('movecapture') moveCaptureElement : ElementRef;
+  @ViewChild('primary') primaryElement : ElementRef;
+  @ViewChild('secondary') secondaryElement : ElementRef;
+
+  // TODO: store the initial secondary pane width in a preference.
+  secondaryWidth = DEFAULT_SECONDARY_WIDTH;
+
+  // State for resizing
+  mouseX : number;
+  bounds : ClientRect;
+
+  /**
+   * When the component initializes, capture the initial geometry,
+   * and set up the resizer element.
+   */
+  ngAfterViewInit() {
+    this.bounds = this.wrapperElement.nativeElement.getBoundingClientRect();
+
+    this.reshape();
+  }
+
+  /**
+   * Capture the starting mouse position, and set up
+   * the mouse move capture div for a resize drag.
+   */
+  resizerMouseDown ($event) {
+    this.moveCaptureElement.nativeElement.style.display = 'block';
+    this.secondaryWidth = this.clampSecondaryWidth();
+
+    this.mouseX = $event.clientX;
+  }
+
+  /**
+   * Handle mouse move events on the mouse move capture div.
+   */
+  moveCaptureMouseMove ($event) {
+    this.secondaryWidth = (this.mouseX - $event.clientX) + this.secondaryWidth;
+    this.mouseX = $event.clientX;
+
+    this.reshape();
+  }
+
+  /**
+   * Clamp the secondary panel width value to prevent layout issues.
+   */
+  clampSecondaryWidth () {
+    const minSecondaryWidth = this.secondaryWidth < MIN_PANE_WIDTH ?
+      MIN_PANE_WIDTH :
+      this.secondaryWidth;
+    const clampedSecondaryWidth = this.bounds.width - minSecondaryWidth < MIN_PANE_WIDTH ?
+      this.bounds.width - MIN_PANE_WIDTH :
+      minSecondaryWidth;
+    return clampedSecondaryWidth;
+  }
+
+  /**
+   * Finalize a resize drag, and set secondaryWidth
+   * to reflect what is currently rendered.
+   */
+  moveCaptureMouseUp () {
+    this.moveCaptureElement.nativeElement.style.display = 'none';
+
+    this.secondaryWidth = this.clampSecondaryWidth();
+  }
+
+  /**
+   * Reshape the resizer, primary pane, and secondary pane
+   * based on current component geometry and panel width.
+   */
+  reshape() {
+    const clampedSecondaryWidth = this.clampSecondaryWidth();
+
+    // Set the primary pane width.
+    this.primaryElement.nativeElement.style.width = (this.bounds.width - clampedSecondaryWidth) + 'px';
+    this.primaryElement.nativeElement.style.minWidth = (this.bounds.width - clampedSecondaryWidth) + 'px';
+
+    // Set the secondary pane width.
+    this.secondaryElement.nativeElement.style.width = clampedSecondaryWidth + 'px';
+    this.secondaryElement.nativeElement.style.minWidth = clampedSecondaryWidth + 'px';
+
+    // Place the resizer bar where it is expected.
+    this.resizerElement.nativeElement.style.right = clampedSecondaryWidth + 'px';
+    this.resizerElement.nativeElement.style.height = this.bounds.height + 'px';
+    this.resizerElement.nativeElement.style.top = this.bounds.top + 'px';
+  }
+
+  /**
+   * No event is fired when an individual element's size changes, so
+   * the best we can do for now is reshape when window is resized.
+   */
+  windowResized () {
+    this.bounds = this.wrapperElement.nativeElement.getBoundingClientRect();
+
+    this.reshape();
+  }
+}

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -1,21 +1,25 @@
-import {enableProdMode} from '@angular/core';
-import {Component, NgZone} from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import {Dispatcher} from './dispatcher/dispatcher';
-import {BackendActions} from './actions/backend-actions/backend-actions';
-import {UserActions} from './actions/user-actions/user-actions';
-import {UserActionType} from './actions/action-constants';
-import {ComponentDataStore} from './stores/component-data/component-data-store';
-import {BackendMessagingService} from './channel/backend-messaging-service';
-import {TreeView} from './components/tree-view/tree-view';
-import {InfoPanel} from './components/info-panel/info-panel';
-import AppTrees from './components/app-trees/app-trees';
-import {Header} from './components/header/header';
+import {
+  Component,
+  NgModule,
+  NgZone,
+  enableProdMode,
+} from '@angular/core';
 import * as Rx from 'rxjs';
-import {ParseUtils} from './utils/parse-utils';
-import { NgModule } from '@angular/core';
+import AppTrees from './components/app-trees/app-trees';
+import SplitPane from './components/split-pane/split-pane';
+import { BackendActions } from './actions/backend-actions/backend-actions';
+import { BackendMessagingService } from './channel/backend-messaging-service';
 import { BrowserModule } from '@angular/platform-browser';
+import { ComponentDataStore } from './stores/component-data/component-data-store';
+import { Dispatcher } from './dispatcher/dispatcher';
 import { FormsModule } from '@angular/forms';
+import { Header } from './components/header/header';
+import { InfoPanel } from './components/info-panel/info-panel';
+import { TreeView } from './components/tree-view/tree-view';
+import { UserActionType } from './actions/action-constants';
+import { UserActions } from './actions/user-actions/user-actions';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { ParseUtils } from './utils/parse-utils';
 
 const BASE_STYLES = require('!style!css!postcss!../styles/app.css');
 
@@ -26,7 +30,7 @@ const ALLOWED_DEPTH: number = 3;
 @Component({
   selector: 'bt-app',
   providers: [ParseUtils],
-  directives: [TreeView, InfoPanel, AppTrees, Header],
+  directives: [AppTrees, Header, InfoPanel, SplitPane, TreeView],
   template: `
     <div class="clearfix vh-100 overflow-hidden flex flex-column"
       [ngClass]="{'dark': theme === 'dark'}">
@@ -35,34 +39,17 @@ const ALLOWED_DEPTH: number = 3;
         [theme]="theme"
         (newTheme)="themeChanged($event)">
       </augury-header>
-      <div class="flex flex-auto">
-        <div class="col col-6 overflow-hidden
-          border-right border-color-dark flex"
-        [ngClass]="{'overflow-scroll col-12': selectedTabIndex > 0}">
-          <bt-app-trees
-            class="flex flex-column flex-auto bg-white"
-            [selectedTabIndex]="selectedTabIndex"
-            [selectedNode]="selectedNode"
-            [closedNodes]="closedNodes"
-            [routerTree]="routerTree"
-            [tree]="tree"
-            [theme]="theme"
-            [changedNodes]="changedNodes"
-            [allowedComponentTreeDepth]="allowedComponentTreeDepth"
-            (tabChange)="tabChange($event)">
-          </bt-app-trees>
-        </div>
-        <div class="col col-6 overflow-hidden"
-          [ngClass]="{'flex': selectedTabIndex === 0}"
-          [hidden]="selectedTabIndex > 0">
-          <bt-info-panel
-            class="flex flex-column flex-auto bg-white"
-            [tree]="tree"
-            [theme]="theme"
-            [node]="selectedNode">
-          </bt-info-panel>
-        </div>
-      </div>
+      <bt-app-trees class="flex flex-column flex-auto"
+        [selectedTabIndex]="selectedTabIndex"
+        [selectedNode]="selectedNode"
+        [closedNodes]="closedNodes"
+        [routerTree]="routerTree"
+        [tree]="tree"
+        [theme]="theme"
+        [changedNodes]="changedNodes"
+        [allowedComponentTreeDepth]="allowedComponentTreeDepth"
+        (tabChange)="tabChange($event)">
+      </bt-app-trees>
     </div>`
 })
 /**
@@ -198,4 +185,3 @@ if (process.env.NODE_ENV !== 'development') {
 
 // --- Bootstrap the module containing our root component on the web browser.
 platformBrowserDynamic().bootstrapModule(FrontendModule);
-

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -18,6 +18,11 @@
 /* dark theme */
 
 .dark {
+  background-color: rgb(36, 36, 36) !important;
+
+  split-pane-secondary-content {
+    border-left: 1px solid rgb(64%, 64%, 64%) !important;
+  }
 
   & .bg-panel {
     background-color: rgb(42, 42, 42) !important;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -3,8 +3,19 @@
 
 html,
 body {
+  /* Override basscss default white background to prevent a white flash during load. */
+  background-color: inherit !important;
+
   font-size: 11px;
   font-family: '.SFNSDisplay-Regular', 'Helvetica Neue', 'Lucida Grande', sans-serif;
+}
+
+bt-tab-menu > header {
+  padding-left: 5px;
+}
+
+split-pane-secondary-content {
+  border-left: 1px solid rgb(92, 92, 92);
 }
 
 .monospace {
@@ -13,6 +24,10 @@ body {
 
 .vh-100 {
   height: 100vh;
+}
+
+.mh100pct {
+  max-height: 100%;
 }
 
 .tab-menu-title {

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,7 @@
     "indent": [true, "spaces"],
     "label-position": true,
     "label-undefined": true,
-    "max-line-length": [true, 80],
+    "max-line-length": [true, 120],
     "no-arg": true,
     "no-bitwise": true,
     "no-console": [true,


### PR DESCRIPTION
 - Move the component info panel under the top tab bar.
 - Fix tab component left margin.
 - Fix global background color to avoid a white flash during load.
 - Clean up frontend.ts imports.

Addresses #537 and #542; includes a small piece of #543.

I'm unsure of how/whether to write automated tests for this; the tests would effectively be a rote mirror of the code itself, and they would be considerably larger. 