### PR TITLE
* Add back Dependencies accordion / dependency / 'change detection' view in info panel

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -6,9 +6,10 @@ import {
   MutableTree,
   Node,
   Path,
-  createTreeFromElements,
   deserializePath,
 } from '../tree';
+
+import {createTreeFromElements} from '../tree/mutable-tree-factory';
 
 import {
   Message,

--- a/src/frontend/actions/user-actions/user-actions.ts
+++ b/src/frontend/actions/user-actions/user-actions.ts
@@ -79,10 +79,6 @@ export class UserActions {
     return this.connection.send(MessageFactory.highlight([node]));
   }
 
-  getDependencies(dependency: string) {
-    throw new Error('Not implemented');
-  }
-
   renderRouterTree(): Promise<Route[]> {
     return this.connection.send<Route[], any>(MessageFactory.routerTree());
   }

--- a/src/frontend/components/component-info/component-info.html
+++ b/src/frontend/components/component-info/component-info.html
@@ -130,7 +130,8 @@
     <accordion sectionTitle="Dependencies" *ngIf="hasDependencies">
       <section-content>
         <bt-dependency
-          [dependencies]="node.dependencies"
+          [tree]="tree"
+          [selectedNode]="node"
           (selectionChange)="selectionChange.emit($event)">
         </bt-dependency>
       </section-content>

--- a/src/frontend/components/component-info/component-info.ts
+++ b/src/frontend/components/component-info/component-info.ts
@@ -23,6 +23,7 @@ import PropertyValue from '../property-value/property-value';
 import {
   Node,
   Path,
+  MutableTree,
   deserializePath,
 } from '../../../tree';
 
@@ -46,6 +47,7 @@ export enum EmitState {
 })
 export class ComponentInfo {
   @Input() node: Node;
+  @Input() tree: MutableTree;
   @Input() state;
   @Input() loadingState: ComponentLoadState;
 

--- a/src/frontend/components/dependency/dependency.html
+++ b/src/frontend/components/dependency/dependency.html
@@ -1,12 +1,11 @@
 <!--dependencies view-->
-<div class="mxn4 myn2"
-  *ngIf="!(depComps && depComps.length > 0)">
+<div class="mxn4 myn2" *ngIf="!hasDependencies">
   <ul class="list-reset m0">
     <li class="border-bottom py2 px4"
       *ngFor="let dep of dependencies">
       <a href="#"
         class="node-item-property"
-        (click)="findDependency(dep)">
+        (click)="onDependencySelected(dep)">
         {{dep}}
         </a>
     </li>
@@ -14,32 +13,30 @@
 </div>
 
 <!--dependent components view-->
-<div class="mxn4 myn2"
-  *ngIf="currDep != ''">
+<div class="mxn4 myn2" *ngIf="selectedDependency">
   <div class="border-bottom py2 px4">
     <a href="#"
       class="icon double-arrow rotate180"
-      (click)="navBack()">
+      (click)="onBack()">
       </a>
     <span class="node-item-property inline-block">
-      {{currDep}}
+      {{selectedDependency}}
       </span>
   </div>
 
-  <ul class="list-reset primary-color m0"
-    *ngIf="(depComps && depComps.length > 0)">
+  <ul class="list-reset primary-color m0" *ngIf="hasDependencies">
     <li class="border-bottom py2 px4"
-      *ngFor="let comp of depComps">
+      *ngFor="let comp of dependentComponents">
       <a href="#"
         class="node-item-property"
-        (click)="selectComponent(comp)">
+        (click)="onSelectComponent(comp)">
         {{comp.name}} (a-id = {{comp.id}})
         </a>
       <ul>
         <li *ngFor="let dep of comp.dependencies">
           <a href="#"
             class="node-item-property"
-            (click)="findDependency(dep)">
+            (click)="onDependencySelected(dep)">
             {{dep}}
             </a>
         </li>

--- a/src/frontend/components/info-panel/info-panel.html
+++ b/src/frontend/components/info-panel/info-panel.html
@@ -6,6 +6,7 @@
 
 <bt-component-info
   [node]="node"
+  [tree]="tree"
   [loadingState]="loadingState"
   [state]="state"
   [hidden]="selectedTab !== StateTab.Properties"

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -24,10 +24,11 @@ import {
   MutableTree,
   Node,
   Path,
-  createTree,
   deserializeChangePath,
   serializePath,
 } from '../tree';
+
+import {createTree} from '../tree/mutable-tree-factory';
 
 import {deserialize} from '../utils';
 

--- a/src/frontend/utils/index.ts
+++ b/src/frontend/utils/index.ts
@@ -3,4 +3,4 @@ export * from './parse-data';
 export * from './parse-utils';
 export * from './object-types';
 export * from './match';
-
+export * from './stack';

--- a/src/frontend/utils/parse-utils.test.ts
+++ b/src/frontend/utils/parse-utils.test.ts
@@ -1,6 +1,7 @@
 import * as test from 'tape';
 import {ParseUtils} from './parse-utils';
-import {MutableTree, createTree} from '../../tree';
+import {MutableTree} from '../../tree/mutable-tree';
+import {createTree} from '../../tree/mutable-tree-factory';
 
 test('utils/parse-utils: copyParent', t => {
   t.plan(1);

--- a/src/frontend/utils/stack.ts
+++ b/src/frontend/utils/stack.ts
@@ -1,0 +1,22 @@
+export class Stack<T> {
+  private elements: Array<T> = [];
+
+  get size(): number {
+    return this.elements.length;
+  }
+
+  clear() {
+    this.elements.splice(0, this.elements.length);
+  }
+
+  push(element: T) {
+    this.elements.push(element);
+  }
+
+  pop(): T {
+    if (this.elements.length === 0) {
+      return null;
+    }
+    return this.elements.pop();
+  }
+}

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -1,6 +1,5 @@
 export * from './change';
 export * from './node';
 export * from './path';
-export * from './transformer';
 export * from './mutable-tree';
 

--- a/src/tree/mutable-tree-factory.ts
+++ b/src/tree/mutable-tree-factory.ts
@@ -1,0 +1,27 @@
+import {DebugElement} from '@angular/core';
+
+import {MutableTree} from './mutable-tree';
+import {transform} from './transformer';
+import {Node} from './node';
+
+export const transformToTree = (root, index: number, includeElements: boolean) => {
+  const map = new Map<string, Node>();
+  try {
+    return transform(null, [index], root, map, includeElements);
+  }
+  finally {
+    map.clear(); // release references
+  }
+};
+
+export const createTree = (roots: Array<Node>) => {
+  const tree = new MutableTree();
+  tree.roots = roots;
+  return tree;
+};
+
+export const createTreeFromElements = (roots: Array<DebugElement>, includeElements: boolean) => {
+  const tree = new MutableTree();
+  tree.roots = roots.map((r, index) => transformToTree(r, index, includeElements));
+  return tree;
+};

--- a/src/tree/mutable-tree.ts
+++ b/src/tree/mutable-tree.ts
@@ -1,33 +1,8 @@
-import {DebugElement} from '@angular/core';
-
 import {Change} from './change';
 import {Node} from './node';
 import {deserialize} from '../utils';
-import {transform} from './transformer';
 import {Path, deserializePath} from './path';
 import {apply, compare} from '../utils/patch';
-
-export const transformToTree = (root, index: number, includeElements: boolean) => {
-  const map = new Map<string, Node>();
-  try {
-    return transform(null, [index], root, map, includeElements);
-  }
-  finally {
-    map.clear(); // release references
-  }
-};
-
-export const createTree = (roots: Array<Node>) => {
-  const tree = new MutableTree();
-  tree.roots = roots;
-  return tree;
-};
-
-export const createTreeFromElements = (roots: Array<DebugElement>, includeElements: boolean) => {
-  const tree = new MutableTree();
-  tree.roots = roots.map((r, index) => transformToTree(r, index, includeElements));
-  return tree;
-};
 
 export class MutableTree {
   public roots: Array<Node>;

--- a/src/tree/node.ts
+++ b/src/tree/node.ts
@@ -8,6 +8,7 @@ export interface EventListener {
 export interface Node {
   id: string;
   isComponent: boolean;
+  changeDetection: string;
   description: Array<Property>;
   nativeElement: () => HTMLElement; // null on frontend
   listeners: Array<EventListener>;

--- a/src/tree/transformer.ts
+++ b/src/tree/transformer.ts
@@ -16,12 +16,9 @@ import {
 
 import {Node} from './node';
 
-import {
-  Path,
-  serializePath
-} from './path';
+import {Path, serializePath} from './path';
 
-import {serialize} from '../utils';
+import {functionName, serialize} from '../utils';
 
 type Source = DebugElement & DebugNode;
 
@@ -62,7 +59,7 @@ export const transform = (parentNode: Node, path: Path, element: Source,
     const name = (() => {
       if (element.componentInstance &&
           element.componentInstance.constructor) {
-        return element.componentInstance.constructor.name;
+        return functionName(element.componentInstance.constructor);
       }
       else if (element.name) {
         return element.name;
@@ -72,7 +69,7 @@ export const transform = (parentNode: Node, path: Path, element: Source,
       }
     })();
 
-    const injectors = element.providerTokens.map(t => t.name);
+    const injectors = element.providerTokens.map(t => functionName(t));
 
     const dependencies = () => {
       if (element.componentInstance == null) {
@@ -82,7 +79,7 @@ export const transform = (parentNode: Node, path: Path, element: Source,
       const parameters = Reflect.getOwnMetadata('design:paramtypes',
         element.componentInstance.constructor) || [];
 
-      return parameters.map(param => param.name);
+      return parameters.map(param => functionName(param));
     };
 
     const providers = getComponentProviders(element, name);
@@ -207,7 +204,7 @@ const getMetadata = (element: Source): ComponentMetadata => {
     Reflect.getOwnMetadata('annotations', element.componentInstance.constructor);
   if (annotations) {
     for (const decorator of annotations) {
-      if (decorator.constructor.name === (<any>ComponentMetadata).name) {
+      if (functionName(decorator.constructor) === functionName(ComponentMetadata)) {
         return decorator;
       }
     }
@@ -220,7 +217,7 @@ const getComponentDirectives = (metadata: ComponentMetadata): Array<string> => {
     return [];
   }
 
-  return metadata.directives.map((d: any) => d.name);
+  return metadata.directives.map(d => functionName(d as any));
 };
 
 const getComponentInputs = (metadata: ComponentMetadata, element: Source) => {
@@ -230,7 +227,7 @@ const getComponentInputs = (metadata: ComponentMetadata, element: Source) => {
 
   eachProperty(element,
     (key: string, meta) => {
-      if (meta.constructor.name === (<any>InputMetadata).name && inputs.indexOf(key) < 0) {
+      if (functionName(meta.constructor) === functionName(InputMetadata) && inputs.indexOf(key) < 0) {
         const property = meta.bindingPropertyName
           ? `${key}:${meta.bindingPropertyName}`
           : key;
@@ -248,7 +245,7 @@ const getComponentOutputs = (metadata: ComponentMetadata, element: Source): Arra
 
   eachProperty(element,
     (key: string, meta) => {
-      if (meta.constructor.name === (<any>OutputMetadata).name && outputs.indexOf(key) < 0) {
+      if (functionName(meta.constructor) === functionName(OutputMetadata) && outputs.indexOf(key) < 0) {
         outputs.push(key);
       }
     });

--- a/src/utils/function-name.ts
+++ b/src/utils/function-name.ts
@@ -1,0 +1,16 @@
+/// Extract the name of a function (the `name' property does not appear to be set
+/// in some cases). A variant of this appeared in older Augury code and it appears
+/// to cover the cases where name is not available as a property.
+export const functionName = (fn: Function): string => {
+  const extract = (value: string) => value.match(/^function ([^\(]*)\(/);
+
+  let name: string = (<any>fn).name;
+  if (name == null || name.length === 0) {
+    const match = extract(fn.toString());
+    if (match.length > 1) {
+      return match[1];
+    }
+    return null;
+  }
+  return name;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './configuration';
+export * from './function-name';
 export * from './ng-validate';
 export * from './serialize';
 export * from './serialize-binary';


### PR DESCRIPTION
* Add back Dependencies accordion / dependency view in info panel
* Add back missing Change Detection section
* Change import statements to avoid importing Angular into
  content-script since it is completely unnecessary in there.
  The only places we use Angular is in backend and frontend,
  and backend runs in a separate context from content-script.
  (This change was also necessary for change detection display)