### PR TITLE
Relatively minor performance fixes

### DIFF
--- a/src/frontend/components/render-state/render-state.ts
+++ b/src/frontend/components/render-state/render-state.ts
@@ -10,6 +10,7 @@ import StateValues from '../state-values/state-values';
 import {
   isObservable,
   isSubject,
+  isLargeArray,
 } from '../../utils';
 
 const defaultExpansionDepth = 1;
@@ -43,6 +44,9 @@ export default class RenderState {
       return this.expansionState[key];
     }
     if (isObservable(this.state[key])) { // do not expand observables (default)
+      return false;
+    }
+    if (isLargeArray(this.state[key])) { // same for large arrays which take a long time to render
       return false;
     }
     return this.level <= defaultExpansionDepth; // default depth

--- a/src/frontend/utils/object-types.ts
+++ b/src/frontend/utils/object-types.ts
@@ -12,3 +12,9 @@ export const isSubject = object => {
   return isObservable(object) && object.hasOwnProperty('hasError');
 };
 
+export const isLargeArray = object => {
+  if (Array.isArray(object) === false) {
+    return false;
+  }
+  return object.length > 100;
+};

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -18,9 +18,6 @@ class Operation {
 
   /// Nodes that have been visited and recorded (-> index)
   visits = new Map<any, number>();
-
-  /// Recursion operations that we want to execute in a shallow call stack
-  tails = new Array<() => void>();
 }
 
 const serializer = object => {
@@ -28,17 +25,6 @@ const serializer = object => {
 
   /// Start the mapping operation at the root.
   map(operation, object);
-
-  /// Avoid recursive operations by adding functions to tails
-  while (operation.tails.length > 0) {
-    const run = operation.tails.length;
-
-    for (let index = 0; index < run; ++index) {
-      operation.tails[index]();
-    }
-
-    operation.tails.splice(0, run);
-  }
 
   /// Return a string representation of the recreator function. The result must
   /// be parseable JavaScript code that can be provided to `new Function()' to
@@ -116,38 +102,34 @@ function map(operation: Operation, value) {
 
           switch (objectType) {
             case '[object Array]':
-              operation.tails.push(() => {
-                operation.objref[index] = `[${value.map((i: number, key) => {
-                  const ref = map(operation, i);
+              operation.objref[index] = `[${value.map((i: number, key) => {
+                const ref = map(operation, i);
 
-                  if (ref instanceof Reference) {
-                    ref.source = index;
-                    ref.key = key;
-                    operation.arrays.push(ref);
-                    return 'null';
-                  }
-                  else {
-                    return ref;
-                  }
-                })}]`;
-              });
+                if (ref instanceof Reference) {
+                  ref.source = index;
+                  ref.key = key;
+                  operation.arrays.push(ref);
+                  return 'null';
+                }
+                else {
+                  return ref;
+                }
+              })}]`;
               break;
             default:
-              operation.tails.push(() => {
-                operation.objref[index] = `{${Object.keys(value).map(key => {
-                  const mapped = map(operation, value[key]);
+              operation.objref[index] = `{${Object.keys(value).map(key => {
+                const mapped = map(operation, value[key]);
 
-                  if (mapped instanceof Reference) {
-                    mapped.source = index;
-                    mapped.key = key;
-                    operation.hashes.push(mapped);
-                    return mapped;
-                  }
+                if (mapped instanceof Reference) {
+                  mapped.source = index;
+                  mapped.key = key;
+                  operation.hashes.push(mapped);
+                  return mapped;
+                }
 
-                  return `${JSON.stringify(key)}: ${mapped}`;
-                }).filter(
-                  v => v instanceof Reference === false).join(',')}}`;
-              });
+                return `${JSON.stringify(key)}: ${mapped}`;
+              }).filter(
+                v => v instanceof Reference === false).join(',')}}`;
               break;
           }
 


### PR DESCRIPTION
 * Revert the recursion change I made to the serializer as it performs way worse than the old implementation
 * Do not expand large arrays by default in the State view because it
   takes a long time to render them
(Note: There is a big performance fix coming around message transmission but this is not it)