### PR TITLE
Introduce state property metadata system + ability to manually emit values to rxjs Subject/AsyncSubject/BehaviorSubject/etc (as with @Output() event emitters)

### DIFF
--- a/src/frontend/components/app-trees/app-trees.html
+++ b/src/frontend/components/app-trees/app-trees.html
@@ -21,7 +21,7 @@
        [tree]="tree"
        [node]="selectedNode"
        [loadingState]="componentState.loadingState(selectedNode)"
-       [state]="componentState.componentInstance(selectedNode)"
+       [instanceValue]="componentState.componentInstance(selectedNode)"
        (selectionChange)="selectionChange.emit($event)">
     </bt-info-panel>
   </div>

--- a/src/frontend/components/component-info/component-info.html
+++ b/src/frontend/components/component-info/component-info.html
@@ -70,6 +70,7 @@
                  [id]="node.id"
                  [inputs]="inputs"
                  [outputs]="outputs"
+                 [metadata]="metadata"
                  [level]="0"
                  [path]="path"
                  [state]="state">

--- a/src/frontend/components/component-info/component-info.ts
+++ b/src/frontend/components/component-info/component-info.ts
@@ -12,6 +12,7 @@ import {Property} from '../../../backend/utils/description';
 import {InputOutput} from '../../../frontend/utils';
 
 import {
+  Metadata,
   MutableTree,
   Node,
   Path,
@@ -26,6 +27,7 @@ export class ComponentInfo {
   @Input() node: Node;
   @Input() tree: MutableTree;
   @Input() state;
+  @Input() metadata: Metadata;
   @Input() loadingState: ComponentLoadState;
 
   @Output() private selectionChange = new EventEmitter<Node>();

--- a/src/frontend/components/info-panel/info-panel.html
+++ b/src/frontend/components/info-panel/info-panel.html
@@ -9,6 +9,7 @@
   [tree]="tree"
   [loadingState]="loadingState"
   [state]="state"
+  [metadata]="metadata"
   [hidden]="selectedTab !== StateTab.Properties"
   [ngClass]="{flex: selectedTab === StateTab.Properties}"
   (selectionChange)="selectionChange.emit($event)">

--- a/src/frontend/components/info-panel/info-panel.ts
+++ b/src/frontend/components/info-panel/info-panel.ts
@@ -7,9 +7,15 @@ import {
 } from '@angular/core';
 
 import {ComponentLoadState} from '../../state';
-import {Node} from '../../../tree';
 import {StateTab} from '../../state';
 import {UserActions} from '../../actions/user-actions/user-actions';
+import {
+  InstanceValue,
+  Metadata,
+  Path,
+  PropertyMetadata,
+  Node,
+} from '../../../tree';
 
 @Component({
   selector: 'bt-info-panel',
@@ -18,7 +24,7 @@ import {UserActions} from '../../actions/user-actions/user-actions';
 export class InfoPanel {
   @Input() tree;
   @Input() node;
-  @Input() state;
+  @Input() instanceValue: InstanceValue;
   @Input() loadingState: ComponentLoadState;
 
   @Output() private selectionChange = new EventEmitter<Node>();
@@ -38,6 +44,21 @@ export class InfoPanel {
     }];
 
   constructor(private userActions: UserActions) {}
+
+  private get state() {
+    if (this.instanceValue) {
+      return this.instanceValue.instance;
+    }
+    return null;
+  }
+
+  private get metadata(): Metadata {
+    if (this.instanceValue) {
+      return this.instanceValue.metadata;
+    }
+
+    return new Map<string, PropertyMetadata>();
+  }
 
   private onSelectedTabChanged(tab: StateTab) {
     this.selectedTab = tab;

--- a/src/frontend/components/property-editor/property-editor.html
+++ b/src/frontend/components/property-editor/property-editor.html
@@ -1,8 +1,8 @@
 <div [ngClass]="{'property-editor': true, editing: state === State.Write}" (click)="onClick($event)">
   <span class="info-key">
     <div class="expander transparent"></div>
-    <span *ngIf="level === 0 && inputs[key]" class="primary-color decorator">
-      @Input(<span class="info-value" [hidden]="!inputs[key].alias">'{{inputs[key].alias}}'</span>)
+    <span *ngIf="isInput" class="primary-color decorator">
+      @Input(<span class="info-value" [hidden]="!inputs[key] || !inputs[key].alias">'{{inputs[key].alias}}'</span>)
     </span>
     {{key}}:
   </span>

--- a/src/frontend/components/property-editor/property-editor.ts
+++ b/src/frontend/components/property-editor/property-editor.ts
@@ -1,5 +1,6 @@
 import {
   ChangeDetectorRef,
+  ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
@@ -13,6 +14,7 @@ const keycode = require('keycode');
 import {InputOutput} from '../../utils';
 import {Highlightable} from '../../utils/highlightable';
 import {highlightTime} from '../../../utils/configuration';
+import {PropertyMetadata} from '../../../tree';
 
 /// The types of values that this editor can emit to its owner
 export type EditorType = string | number | Object | Function;
@@ -30,11 +32,13 @@ export enum State {
   selector: 'bt-property-editor',
   template: require('./property-editor.html'),
   styles: [require('to-string!./property-editor.css')],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropertyEditor {
   @Input() key: string;
   @Input() level: number;
   @Input() inputs: InputOutput;
+  @Input() metadata: PropertyMetadata;
   @Input() private initialValue;
 
   @Output() private cancel = new EventEmitter<void>();
@@ -62,8 +66,10 @@ export class PropertyEditor {
     this.editor.focus();
   }
 
-  private ngOnChanges() {
-    this.value = this.initialValue;
+  private ngOnChanges(changes: SimpleChanges) {
+    if (this.hasChanged(changes)) {
+      this.value = this.initialValue;
+    }
   }
 
   private ngAfterViewChecked() {
@@ -72,15 +78,17 @@ export class PropertyEditor {
     }
   }
 
-  private parseValue(): EditorResult {
-    const value = this.value;
+  private get isInput(): boolean {
+    return (this.metadata & PropertyMetadata.Input) !== 0;
+  }
 
+  private parseValue(value): EditorResult {
     try {
-      return JSON.parse(value);
+      return new Function(`return ${value}`)();
     }
-    catch (e) {}
-
-    return value;
+    catch (e) {
+      return value;
+    }
   }
 
   private hasChanged(changes: SimpleChanges) {
@@ -139,7 +147,11 @@ export class PropertyEditor {
   }
 
   private accept() {
-    this.submit.emit(this.parseValue());
+    const parsed = this.parseValue(this.value);
+
+    this.submit.emit(parsed);
+
+    this.initialValue = parsed;
 
     this.transition(State.Read);
   }

--- a/src/frontend/components/render-state/render-state.css
+++ b/src/frontend/components/render-state/render-state.css
@@ -44,7 +44,6 @@
   margin-top: 2px;
   right: 5em;
   font-size: 1.2em;
-  z-index: 10;
 }
 
 .emitted {

--- a/src/frontend/components/render-state/render-state.html
+++ b/src/frontend/components/render-state/render-state.html
@@ -7,40 +7,42 @@
   <span class="property-container"
      (click)="expandTree(k, $event)"
      *ngIf="nest(k)">
-    <span class="info-key" [ngClass]="{output: classification(k) === StateClassification.Output}">
+    <span class="info-key" [ngClass]="{output: isEmittable(k)}">
       <div [ngClass]="{
         expander: true,
         rotate90: !expanded(k),
-        transparent: keys(state[k]).length === 0
+        transparent: !expandable(k)
       }"></div>
-      <span [ngSwitch]="classification(k)" class="primary-color">
-        <span *ngSwitchCase="StateClassification.Input" class="decorator">@Input(<span class="info-value" [hidden]="!inputs[k].alias">'{{inputs[k].alias}}'</span>)</span>
-        <span *ngSwitchCase="StateClassification.Output" class="decorator">@Output(<span class="info-value" [hidden]="!outputs[k].alias">'{{outputs[k].alias}}'</span>)</span>
+      <span class="primary-color">
+        <span *ngIf="has(k, PropertyMetadata.Input)" class="decorator">
+          @Input(<span class="info-value" [hidden]="!inputs[k].alias">'{{inputs[k].alias}}'</span>)
+        </span>
+        <span *ngIf="has(k, PropertyMetadata.Output)" class="decorator">
+          @Output(<span class="info-value" [hidden]="!outputs[k].alias">'{{outputs[k].alias}}'</span>)
+        </span>
       </span>
       {{k}}:
     </span>
-    <span [ngSwitch]="classification(k)" class="classification">
-      <span *ngSwitchCase="StateClassification.Output" class="emitter">
-        <input class="editable" type="text" #prop />
-        <div [ngSwitch]="emitState.get(k)" class="emit-state">
-          <span *ngSwitchCase="EmitState.Emitted" class="emitted">✔</span>
-          <span *ngSwitchCase="EmitState.Failed" class="failed">✘</span>
-        </div>
-        <button class="btn btn-primary bg-olive mb1"
-          (click)="emitValue(k, prop.value)">
-          Emit
-        </button>
-      </span>
-      <span *ngSwitchDefault class="info-value">
-        {{displayType(state[k])}}
-      </span>
+    <span *ngIf="isEmittable(k)" class="emitter">
+      <input class="editable" type="text" #prop />
+      <div [ngSwitch]="emitState.get(k)" class="emit-state">
+        <span *ngSwitchCase="EmitState.Emitted" class="emitted">✔</span>
+        <span *ngSwitchCase="EmitState.Failed" class="failed">✘</span>
+      </div>
+      <button class="btn btn-primary bg-olive mb1"
+        (click)="emitValue(k, prop.value)">
+        Emit
+      </button>
+    </span>
+    <span *ngIf="!isEmittable(k)" class="info-value">
+      {{displayType(k)}}
     </span>
   </span>
   <bt-state-values
      *ngIf="nest(k) === false"
      [id]="id"
      [inputs]="inputs"
-     [level]="level"
+     [metadata]="metadataForKey(k)"
      [path]="path.concat([k])"
      [value]="state[k]">
   </bt-state-values>
@@ -50,6 +52,7 @@
        [id]="id"
        [level]="level + 1"
        [path]="path.concat([k])"
+       [metadata]="metadata"
        [state]="state[k]">
     </bt-render-state>
   </div>

--- a/src/frontend/components/state-values/state-values.html
+++ b/src/frontend/components/state-values/state-values.html
@@ -1,8 +1,8 @@
 <div [ngClass]="{changed: isUpdated, property: true}">
   <bt-property-editor
      [key]="key"
-     [level]="level"
      [inputs]="inputs"
+     [metadata]="metadata"
      [initialValue]="value"
      (submit)="onValueChanged($event)">
   </bt-property-editor>

--- a/src/frontend/components/state-values/state-values.ts
+++ b/src/frontend/components/state-values/state-values.ts
@@ -6,8 +6,13 @@ import {
 
 import {UserActions} from '../../actions/user-actions/user-actions';
 import {Highlightable} from '../../utils/highlightable';
-import {Path} from '../../../tree';
 import {InputOutput} from '../../utils';
+import {functionName} from '../../../utils';
+import {
+  Path,
+  PropertyMetadata,
+  Metadata,
+} from '../../../tree';
 
 @Component({
   selector: 'bt-state-values',
@@ -16,9 +21,9 @@ import {InputOutput} from '../../utils';
 })
 export class StateValues extends Highlightable {
   @Input() id: string | number;
-  @Input() inputs: InputOutput;
-  @Input() level: number;
   @Input() path: Path;
+  @Input() inputs: InputOutput;
+  @Input() metadata: PropertyMetadata;
   @Input() value;
 
   private editable: boolean = false;
@@ -40,6 +45,10 @@ export class StateValues extends Highlightable {
 
     if (oldValue.toString() === 'CD_INIT_VALUE') {
       return false;
+    }
+
+    if (oldValue === 'function' && typeof newValue === 'function') {
+      return functionName(oldValue) !== functionName(newValue);
     }
 
     return oldValue !== newValue;

--- a/src/frontend/components/state-values/state-values.ts
+++ b/src/frontend/components/state-values/state-values.ts
@@ -47,7 +47,7 @@ export class StateValues extends Highlightable {
       return false;
     }
 
-    if (oldValue === 'function' && typeof newValue === 'function') {
+    if (typeof oldValue === 'function' && typeof newValue === 'function') {
       return functionName(oldValue) !== functionName(newValue);
     }
 

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -259,10 +259,7 @@ class App {
       this.componentState.wait(node, promise);
     }
     else {
-      this.directConnection.handleImmediate(m)
-        .then(() => {
-          this.componentState.done(node, null);
-        });
+      this.componentState.wait(node, this.directConnection.handleImmediate(m).then(() => null));
     }
   }
 

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -1,4 +1,5 @@
 export * from './change';
+export * from './metadata';
 export * from './node';
 export * from './path';
 export * from './mutable-tree';

--- a/src/tree/metadata.ts
+++ b/src/tree/metadata.ts
@@ -1,0 +1,119 @@
+import {EventEmitter} from '@angular/core';
+
+import {
+  AsyncSubject,
+  BehaviorSubject,
+  ReplaySubject,
+  Subscriber,
+  Observable,
+  Subject,
+} from 'rxjs';
+
+import {
+  Path,
+  serializePath,
+} from './path';
+
+import {functionName} from '../utils';
+
+export enum PropertyMetadata {
+  Input         = 0x1,
+  Output        = 0x2,
+  Subject       = 0x4,
+  Observable    = 0x8,
+  EventEmitter  = 0x10,
+}
+
+export type Metadata = Map<any, PropertyMetadata>;
+
+export interface InstanceValue {
+  instance;
+  metadata: any | Metadata;
+}
+
+export const instanceWithMetadata =
+    (instance, inputs: Set<string>, outputs: Set<string>): InstanceValue => {
+  const map = new Map<any, PropertyMetadata>();
+
+  if (instance != null) {
+    for (const key of Object.keys(instance)) {
+      loadMetadata(inputs, outputs, instance[key], key, map);
+    }
+  }
+
+  const metadataArray = new Array<any>();
+
+  map.forEach(
+    (value, key) => {
+      if (value !== 0) { // zero is not worth serializing and sending to UI
+        metadataArray.push([key, value]);
+      }
+    });
+
+  // It is very important that both the instance and metadata objects are part
+  // of the same object so that they get serialized together in {@link serialize}.
+  // This is because both instance and metadata refer to the same object instances,
+  // so they must be serialized together for those references to remain intact.
+  return {instance, metadata: metadataArray};
+};
+
+const loadMetadata =
+    (inputs: Set<string>, outputs: Set<string>, instance, top: string, map: Metadata) => {
+  if (map.has(instance)) {
+    return;
+  }
+
+  let flags: PropertyMetadata = 0;
+
+  if (instance != null && isScalar(instance) === false) {
+    switch (functionName(instance.constructor)) {
+      case functionName(EventEmitter):
+        flags |= PropertyMetadata.EventEmitter;
+        break;
+      case functionName(AsyncSubject):
+      case functionName(BehaviorSubject):
+      case functionName(ReplaySubject):
+      case functionName(Subject):
+        flags |= PropertyMetadata.Subject | PropertyMetadata.Observable;
+        break;
+      case functionName(Observable):
+      case functionName(Subscriber):
+        flags |= PropertyMetadata.Observable;
+        break;
+      default:
+        for (const key of Object.keys(instance)) {
+          const value = instance[key];
+
+          map.set(instance, flags);
+
+          if (map.has(value) === false) {
+            loadMetadata(inputs, outputs, value, null, map);
+          }
+        }
+        break;
+    }
+  }
+
+  if (top) {
+    if (inputs.has(top)) {
+      flags |= PropertyMetadata.Input;
+    }
+    else if (outputs.has(top)) {
+      flags |= PropertyMetadata.Output;
+    }
+  }
+
+  map.set(instance, flags);
+};
+
+const isScalar = value => {
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+    case 'function':
+    case 'undefined':
+      return true;
+    default:
+      return false;
+  }
+};

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,7 @@
     "label-undefined": true,
     "max-line-length": [true, 120],
     "no-arg": true,
-    "no-bitwise": true,
+    "no-bitwise": false,
     "no-console": [true,
       "debug",
       "info",


### PR DESCRIPTION
New property metadata system allows us to treat all rxjs subjects as "emittable" from the Augury UI.

We can now do this kind of thing in the State panel:
<img width="982" alt="screen shot 2016-09-11 at 7 09 27 pm" src="https://cloud.githubusercontent.com/assets/1780164/18421255/7b10b70e-7853-11e6-9b65-add4a7ccc5e8.png">

Whereas before we had to render the same State object like so:
<img width="962" alt="screen shot 2016-09-11 at 7 09 56 pm" src="https://cloud.githubusercontent.com/assets/1780164/18421257/868bdb36-7853-11e6-9478-a88819c5d30c.png">

This also fixes a bug with `@Input()` not appearing where it should