### PR TITLE
Introduce keyboard navigation for the component tree (behaves the same as the Chrome "Elements" keyboard navigation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",
     "file-loader": "^0.8.5",
-    "keycode": "^2.1.4",
     "msgpack-lite": "^0.1.20",
     "object-assign": "4.0.1",
     "postcss-cssnext": "^2.5.2",

--- a/src/frontend/components/app-trees/app-trees.html
+++ b/src/frontend/components/app-trees/app-trees.html
@@ -9,6 +9,7 @@
     <bt-tree-view
        class="flex minheight-100pct"
        [tree]="tree"
+       [selectedNode]="selectedNode"
        (selectionChange)="selectionChange.emit($event)"
        (inspectElement)="inspectElement.emit($event)"
        (collapseChildren)="collapseChildren.emit($event)"

--- a/src/frontend/components/component-tree/component-tree.html
+++ b/src/frontend/components/component-tree/component-tree.html
@@ -1,4 +1,4 @@
-<main class="monospace col-12 p1" *ngIf="tree">
+<main class="monospace col-12 p1" *ngIf="tree" (keydown)="onKeypress($event)" tabindex="0">
   <bt-node-item *ngFor="let node of tree.roots; trackBy: trackById"
     [node]="node"
     [level]="0"

--- a/src/frontend/components/component-tree/component-tree.ts
+++ b/src/frontend/components/component-tree/component-tree.ts
@@ -63,10 +63,6 @@ export class ComponentTree {
     }
   }
 
-  private ngOnInit() {
-    this.el.nativeElement.focus();
-  }
-
   private onKeypress(event: KeyboardEvent) {
     switch (event.key) {
       case 'ArrowUp':

--- a/src/frontend/components/component-tree/component-tree.ts
+++ b/src/frontend/components/component-tree/component-tree.ts
@@ -9,7 +9,15 @@ import {
 import {
   MutableTree,
   Node,
+  deserializePath,
 } from '../../../tree';
+
+import {
+  ComponentViewState,
+  ExpandState,
+} from '../../state';
+
+import {defaultExpansionDepth} from '../node-item/node-item';
 
 @Component({
   selector: 'component-tree',
@@ -18,20 +26,20 @@ import {
   host: {'class': 'flex overflow-scroll'},
 })
 export class ComponentTree {
-  @Input() tree: MutableTree;
+  @Input() private tree: MutableTree;
+  @Input() private selectedNode: Node;
 
   @Output() private selectionChange = new EventEmitter<Node>();
   @Output() private inspectElement = new EventEmitter<Node>();
   @Output() private expandChildren = new EventEmitter<Node>();
   @Output() private collapseChildren = new EventEmitter<Node>();
 
-  private prevSelectedNode: Element;
-
   constructor(
+    private viewState: ComponentViewState,
     private el: ElementRef
   ) {}
 
-  scrollToViewIfNeeded(node) {
+  private scrollToViewIfNeeded(node) {
     const selectedNodeBound = node.getBoundingClientRect();
     const treeViewBound = this.el.nativeElement.getBoundingClientRect();
     const scrollBarHeight = this.el.nativeElement.offsetHeight -
@@ -47,16 +55,175 @@ export class ComponentTree {
     }
   }
 
-  ngAfterViewChecked() {
-    const selectedNode = document.getElementsByClassName('node-item-selected')
-                         .item(0);
-    if (selectedNode && this.prevSelectedNode !== selectedNode) {
+  private ngAfterViewChecked() {
+    const selectedNode = document.getElementsByClassName('node-item-selected').item(0);
+
+    if (selectedNode) {
       this.scrollToViewIfNeeded(selectedNode);
-      this.prevSelectedNode = selectedNode;
     }
   }
 
-  trackById(index: number, node: any): string {
+  private ngOnInit() {
+    this.el.nativeElement.focus();
+  }
+
+  private onKeypress(event: KeyboardEvent) {
+    switch (event.key) {
+      case 'ArrowUp':
+        this.navigateUp();
+        break;
+      case 'ArrowDown':
+        this.navigateDown();
+        break;
+      case 'ArrowLeft':
+        this.collapseSelected();
+        break;
+      case 'ArrowRight':
+        this.expandSelected();
+        break;
+    }
+  }
+
+  private navigateUp() {
+    let previous = this.previousSibling();
+    if (previous == null) {
+      previous = this.getParent(this.selectedNode);
+    }
+    this.select(previous);
+  }
+
+  private navigateDown() {
+    const next = this.nextSibling();
+    if (next) {
+      this.select(next);
+    }
+  }
+
+  private collapseSelected() {
+    if (this.selectedNode) {
+      this.viewState.expandState(this.selectedNode, ExpandState.Collapsed);
+    }
+  }
+
+  private expandSelected() {
+    if (this.selectedNode) {
+      this.viewState.expandState(this.selectedNode, ExpandState.Expanded);
+    }
+  }
+
+  private select(node: Node) {
+    if (node == null) { // first keyboard action when nothing is selected
+      if (this.tree.roots.length === 0) {
+        return;
+      }
+      node = this.tree.roots[0];
+    }
+
+    this.selectionChange.emit(node);
+  }
+
+  private getParent(node: Node): Node {
+    if (node == null) {
+      return null;
+    }
+
+    const path = deserializePath(node.id);
+    path.pop();
+
+    return this.tree.traverse(path);
+  }
+
+  private getSibling(node: Node, increment: number): Node {
+    const parent = this.getParent(node);
+    if (parent == null) {
+      return null;
+    }
+
+    const index = parent.children.indexOf(node) + increment;
+    if (index >= parent.children.length || index < 0) {
+      return null;
+    }
+
+    return parent.children[index];
+  }
+
+  private previousSibling(): Node {
+    return this.seekDepth(this.getSibling(this.selectedNode, -1));
+  }
+
+  private ancestors(node: Node, increment: number): Array<Node> {
+    const nodes = new Array<Node>();
+    while (node) {
+      nodes.push(this.getSibling(node, increment));
+      node = this.getParent(node);
+    }
+    return nodes;
+  }
+
+  private nextSibling(): Node {
+    const choices =
+      this.visible([this.childNode()].concat(this.ancestors(this.selectedNode, 1)));
+
+    if (choices.length > 0) {
+      return choices[0];
+    }
+    return null;
+  }
+
+  private seekDepth(from: Node) {
+    if (from == null) {
+      return null;
+    }
+
+    let flattened = new Array<Node>();
+
+    const apply = (node: Node) => {
+      flattened.push(node);
+
+      node.children.forEach(n => apply(n));
+    };
+
+    apply(from);
+
+    flattened = this.visible(flattened);
+
+    if (flattened.length > 0) {
+      return flattened.pop();
+    }
+
+    return null;
+  }
+
+  private childNode(): Node {
+    if (this.selectedNode == null || this.selectedNode.children.length === 0) {
+      return null;
+    }
+    return this.selectedNode.children[0];
+  }
+
+  private level(node: Node): number {
+    return deserializePath(node.id).length - 1;
+  }
+
+  private visible(nodes: Array<Node>): Array<Node> {
+    return nodes.filter(n => {
+      if (n == null) {
+        return false;
+      }
+
+      // NOTE(cbond): parent must be expanded for this node to be visible
+      let expansionState = this.viewState.expandState(this.getParent(n));
+      if (expansionState == null) {
+        expansionState =
+          this.level(n) <= defaultExpansionDepth
+            ? ExpandState.Expanded
+            : ExpandState.Collapsed;
+      }
+      return expansionState === ExpandState.Expanded;
+    });
+  }
+
+  private trackById(index: number, node: any): string {
     return node.id;
   }
 }

--- a/src/frontend/components/node-item/node-item.ts
+++ b/src/frontend/components/node-item/node-item.ts
@@ -18,7 +18,7 @@ import {NodeAttributes} from './node-attributes';
 import {NodeOpenTag} from './node-open-tag';
 
 /// The number of levels of tree nodes that we expand by default
-const defaultExpansionDepth = 3;
+export const defaultExpansionDepth = 3;
 
 @Component({
   selector: 'bt-node-item',

--- a/src/frontend/components/property-editor/property-editor.ts
+++ b/src/frontend/components/property-editor/property-editor.ts
@@ -8,8 +8,6 @@ import {
   Output,
 } from '@angular/core';
 
-const keycode = require('keycode');
-
 import {InputOutput} from '../../utils';
 import {Highlightable} from '../../utils/highlightable';
 import {highlightTime} from '../../../utils/configuration';
@@ -109,11 +107,11 @@ export class PropertyEditor {
   }
 
   private onKeypress(event: KeyboardEvent) {
-    switch (keycode(event)) {
-      case 'enter':
+    switch (event.key) {
+      case 'Enter':
         this.accept();
         break;
-      case 'esc':
+      case 'Escape':
         this.reject();
         break;
     }

--- a/src/frontend/components/tree-view/tree-view.html
+++ b/src/frontend/components/tree-view/tree-view.html
@@ -1,9 +1,10 @@
 <div class="flex flex-column flex-stretch bg-base col-12 flex-1 overflow-auto minwidth-100pct">
   <component-tree
     [tree]="tree"
+    [selectedNode]="selectedNode"
     (selectionChange)="selectionChange.emit($event)"
     (inspectElement)="inspectElement.emit($event)"
     (collapseChildren)="collapseChildren.emit($event)"
     (expandChildren)="expandChildren.emit($event)">
-    </component-tree>
+  </component-tree>
 </div>

--- a/src/frontend/components/tree-view/tree-view.ts
+++ b/src/frontend/components/tree-view/tree-view.ts
@@ -15,7 +15,8 @@ import {
   template: require('./tree-view.html'),
 })
 export class TreeView {
-  @Input() tree: MutableTree;
+  @Input() private tree: MutableTree;
+  @Input() private selectedNode: Node;
 
   @Output() private selectionChange = new EventEmitter<Node>();
   @Output() private inspectElement = new EventEmitter<Node>();


### PR DESCRIPTION
Also remove keycode library since Chrome provides this functionality on its own (thank you @xorgy)