### PR TITLE
Remove "overflow-scroll" from this div, which causes an extra set

### DIFF
--- a/src/frontend/components/tree-view/tree-view.html
+++ b/src/frontend/components/tree-view/tree-view.html
@@ -1,5 +1,5 @@
 <div class="flex flex-column bg-base minwidth-100pct minheight-100pct">
-  <div class="flex flex-auto overflow-scroll">
+  <div class="flex flex-auto">
     <component-tree
        (collapseChildren)="collapseChildren.emit($event)"
        (expandChildren)="expandChildren.emit($event)"


### PR DESCRIPTION
of empty scrollbars to show up all the time, in addition to the
regular scrollbars in component tree.

These empty scrollbar areas never have scrollbars since it's a div
within the component-tree that scrolls when the tree extends past
the viewport.