### PR TITLE
Add execution context warning to content script

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -121,6 +121,12 @@ checkDebug(() => {
   getAllAngularRootElements().forEach(root => bind(ng.probe(root)));
 });
 
+const selectedComponentPropertyKey = '$a';
+const noSelectedComponentWarningText = 'There is no component selected.';
+
+Object.defineProperty(window, selectedComponentPropertyKey,
+  { value: noSelectedComponentWarningText });
+
 const messageHandler = (message: Message<any>) => {
   switch (message.messageType) {
     case MessageType.Initialize:
@@ -274,9 +280,7 @@ export const routerTree = (): Array<MainRoute> => {
 };
 
 export const consoleReference = (node: Node) => {
-  const propertyKey = '$a';
-
-  Object.defineProperty(window, propertyKey, {
+  Object.defineProperty(window, selectedComponentPropertyKey, {
     get: () => {
       if (node) {
         return ng.probe(node.nativeElement());

--- a/src/content-script.ts
+++ b/src/content-script.ts
@@ -83,3 +83,11 @@ send(MessageFactory.initialize())
   .catch(error => {
     console.error('Augury initialization has failed', error);
   });
+
+const propertyKey = '$a';
+const warningText = `$a will only be set in the 'top' execution context, \
+which you can select via the dropdown in the console pane \
+(https://developers.google.com/web/tools/chrome-devtools/console/\
+#execution-context).`;
+
+Object.defineProperty(window, propertyKey, { value: warningText });


### PR DESCRIPTION
resolves #684 

@xorgy I spent some time looking at the chrome APIs to see how we might be able to add this warning to all execution contexts except the "top" one, but I didn't find anything conclusive (though I did read that it *should* be possible for each execution context to access the `window` object of each of the others).

This adds it in the parent extension context only. If you have any suggestion for improvements, please point me in the right direction.