### PR TITLE
Update router tree with changes

### DIFF
--- a/example-apps/kitchen-sink-example/package.json
+++ b/example-apps/kitchen-sink-example/package.json
@@ -6,7 +6,9 @@
     "start": "webpack-dev-server --display-error-details --display-cached",
     "build": "webpack --display-error-details --display-cached"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "angular2-router-loader": "^0.3.2"
+  },
   "dependencies": {
     "@angular/common": "2.0.0",
     "@angular/compiler": "2.0.0",

--- a/example-apps/kitchen-sink-example/source/components/lazy-load/lazy-load.ts
+++ b/example-apps/kitchen-sink-example/source/components/lazy-load/lazy-load.ts
@@ -1,0 +1,19 @@
+import {Component} from '@angular/core';
+import { NgModule }           from '@angular/core';
+import { Routes, RouterModule }  from '@angular/router';
+
+
+@Component({
+  template: `<H1>Lazy Loaded Component One</H1>`
+})
+class LazyLoadedComponentOne { }
+
+const routes: Routes = [
+  { path: 'lazy1', component: LazyLoadedComponentOne },
+];
+
+@NgModule({
+  imports: [  RouterModule.forChild(routes) ],
+  declarations: [ LazyLoadedComponentOne ]
+})
+export class LazyLoadedModule { }

--- a/example-apps/kitchen-sink-example/source/components/lazy-load/lazy-load.ts
+++ b/example-apps/kitchen-sink-example/source/components/lazy-load/lazy-load.ts
@@ -1,12 +1,12 @@
-import {Component} from '@angular/core';
-import { NgModule }           from '@angular/core';
-import { Routes, RouterModule }  from '@angular/router';
+import { Component } from '@angular/core';
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
 
 
 @Component({
   template: `<H1>Lazy Loaded Component One</H1>`
 })
-class LazyLoadedComponentOne { }
+class LazyLoadedComponentOne {}
 
 const routes: Routes = [
   { path: 'lazy1', component: LazyLoadedComponentOne },

--- a/example-apps/kitchen-sink-example/source/containers/kitchen-sink.routes.ts
+++ b/example-apps/kitchen-sink-example/source/containers/kitchen-sink.routes.ts
@@ -58,6 +58,8 @@ export const KitchenSinkRoutes: Routes = [
   { path: 'demo', component: Demo },
   { path: 'stress-tester', component: StressTester },
   { path: 'metadata-test', component: MetadataTest },
+  { path: 'lazy-load',
+    loadChildren: '../components/lazy-load/lazy-load#LazyLoadedModule' },
 ];
 
 export const KitchenSinkDeclarations = [

--- a/example-apps/kitchen-sink-example/source/containers/kitchen-sink.ts
+++ b/example-apps/kitchen-sink-example/source/containers/kitchen-sink.ts
@@ -15,6 +15,9 @@ import {
       <li [ngClass]="{active: path==''}">
         <a [routerLink]="['/']">Home</a>
       </li>
+      <li [ngClass]="{active: path=='welcome'}">
+        <a [routerLink]="['/lazy-load/lazy1']">Lazy Loaded Module</a>
+      </li>
       <li [ngClass]="{active: path=='demo'}">
         <a [routerLink]="['/demo']">Demo</a>
       </li>

--- a/example-apps/kitchen-sink-example/webpack.config.js
+++ b/example-apps/kitchen-sink-example/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = {
       loader: 'tslint'
     }],
     loaders: [
-      { test: /\.ts$/, loader: 'ts', exclude: /node_modules/ },
+      { test: /\.ts$/, loaders: ['ts', 'angular2-router-loader'], exclude: /node_modules/ },
       { test: /\.html$/, loader: 'raw' },
       { test: /\.css$/, loader: 'style-loader!css-loader?sourceMap' },
       { test: /\.svg/, loader: 'url' },

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -61,7 +61,7 @@ let previousTree: MutableTree;
 
 let previousCount: number;
 
-const updateTree = (roots: Array<DebugElement>) => {
+const updateComponentTree = (roots: Array<DebugElement>) => {
   const {tree, count} = createTreeFromElements(roots, treeRenderOptions);
 
   if (previousTree == null || Math.abs(previousCount - count) > deltaThreshold) {
@@ -86,8 +86,8 @@ const updateTree = (roots: Array<DebugElement>) => {
   previousCount = count;
 };
 
-const update = () => {
-  updateTree(getAllAngularRootElements().map(r => ng.probe(r)));
+const updateRouterTree = (routes: Array<MainRoute>) => {
+  messageBuffer.enqueue(MessageFactory.routerTree(routes));
 };
 
 const subject = new Subject<void>();
@@ -98,7 +98,10 @@ const bind = (root: DebugElement) => {
     ngZone.onStable.subscribe(() => subject.next(void 0));
   }
 
-  subject.debounceTime(0).subscribe(() => update());
+  subject.debounceTime(0).subscribe(() => {
+    updateComponentTree(getAllAngularRootElements().map(r => ng.probe(r)));
+    updateRouterTree(routerTree());
+  });
 
   subject.next(void 0); // initial load
 };

--- a/src/backend/utils/parse-router.ts
+++ b/src/backend/utils/parse-router.ts
@@ -50,7 +50,6 @@ function assignChildrenToParent(parent, children): [any] {
 }
 
 function childRouteName(child): string {
-  // console.debug('child:', child);
   if (child.component) {
     return child.component.name;
   }

--- a/src/backend/utils/parse-router.ts
+++ b/src/backend/utils/parse-router.ts
@@ -32,7 +32,7 @@ export function parseRoutes(router: any): MainRoute {
 function assignChildrenToParent(parent, children): [any] {
   return children.map((child) => {
     const childName = childRouteName(child);
-    const childDescendents: [any] = child.children;
+    const childDescendents: [any] = child._loadedConfig ? child._loadedConfig.routes : child.children;
 
     // only found in aux routes, otherwise property will be undefined
     const isAuxRoute = !!child.outlet;
@@ -50,5 +50,12 @@ function assignChildrenToParent(parent, children): [any] {
 }
 
 function childRouteName(child): string {
-  return child.component ? child.component.name : 'no-name-route';
+  // console.debug('child:', child);
+  if (child.component) {
+    return child.component.name;
+  }
+  if (child.loadChildren) {
+    return `${child.path} [Lazy]`;
+  }
+  return 'no-name-route';
 }

--- a/src/backend/utils/parse-router.ts
+++ b/src/backend/utils/parse-router.ts
@@ -53,8 +53,10 @@ function childRouteName(child): string {
   if (child.component) {
     return child.component.name;
   }
-  if (child.loadChildren) {
+  else if (child.loadChildren) {
     return `${child.path} [Lazy]`;
   }
-  return 'no-name-route';
+  else {
+    return 'no-name-route';
+  }
 }

--- a/src/communication/message-factory.ts
+++ b/src/communication/message-factory.ts
@@ -7,6 +7,10 @@ import {
   messageSource,
 } from './message';
 
+import {
+  MainRoute,
+} from '../backend/utils';
+
 import {MessageType} from './message-type';
 
 import {ApplicationError} from './application-error';
@@ -102,9 +106,10 @@ export abstract class MessageFactory {
     });
   }
 
-  static routerTree(): Message<void> {
+  static routerTree(content: Array<MainRoute>): Message<void> {
     return create({
       messageType: MessageType.RouterTree,
+      content: content,
     });
   }
 
@@ -160,4 +165,3 @@ export abstract class MessageFactory {
     });
   }
 }
-

--- a/src/frontend/actions/user-actions/user-actions.ts
+++ b/src/frontend/actions/user-actions/user-actions.ts
@@ -105,8 +105,5 @@ export class UserActions {
     return this.connection.send(MessageFactory.highlight([node]));
   }
 
-  renderRouterTree(): Promise<Route[]> {
-    return this.connection.send<Route[], any>(MessageFactory.routerTree());
-  }
 }
 

--- a/src/frontend/components/router-tree/router-tree.ts
+++ b/src/frontend/components/router-tree/router-tree.ts
@@ -2,6 +2,7 @@ import {
   Component,
   Input,
   ViewChild,
+  SimpleChanges,
 } from '@angular/core';
 
 import {Route} from '../../../backend/utils';
@@ -34,10 +35,6 @@ export class RouterTree {
 
   constructor(private userActions: UserActions) {}
 
-  ngAfterViewInit() {
-    this.treeConfig = this.getTree();
-  }
-
   private getTree(): TreeConfig {
     const tree = d3.layout.tree();
 
@@ -58,7 +55,7 @@ export class RouterTree {
   }
 
   render() {
-    if (!this.routerTree) {
+    if (!this.routerTree || !this.treeConfig) {
       return;
     }
 
@@ -131,7 +128,11 @@ export class RouterTree {
       .attr('transform', `translate(${ -gElBBox.x + svgPadding },${ -gElBBox.y + svgPadding})`);
   }
 
-  private ngOnChanges() {
+  private ngOnChanges(changes: SimpleChanges) {
+    if (changes['routerTree']) {
+      d3.select(this.chartContainer.nativeElement).select('svg').remove();
+      this.treeConfig = this.getTree();
+    }
     this.render();
   }
 

--- a/src/frontend/components/router-tree/router-tree.ts
+++ b/src/frontend/components/router-tree/router-tree.ts
@@ -129,6 +129,7 @@ export class RouterTree {
   }
 
   private ngOnChanges(changes: SimpleChanges) {
+    // tslint:disable:no-string-literal
     if (changes['routerTree']) {
       d3.select(this.chartContainer.nativeElement).select('svg').remove();
       this.treeConfig = this.getTree();

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -271,22 +271,7 @@ class App {
 
   private onSelectedTabChange(tab: Tab) {
     this.selectedTab = tab;
-
-    if (tab === Tab.RouterTree) {
-      this.userActions.renderRouterTree()
-        .then(response => {
-          this.zone.run(() => {
-            this.routerTree = response;
-          });
-        })
-        .catch(error => {
-          this.error = new ApplicationError(
-            ApplicationErrorType.UncaughtException,
-            error.message,
-            error.stack);
-          this.changeDetector.detectChanges();
-        });
-    }
+    this.routerTree = this.routerTree ? [].concat(this.routerTree) : null;
   }
 
   private extractIdentifiersFromChanges(changes: Array<Change>): string[] {


### PR DESCRIPTION
@igor-ka @xorgy @clbond This isn't complete yet, but I wanted to get some eyes on it. These changes handle clearing and re-rendering the router tree on data change, as well as having the routes loaded from the point as the component tree, rather than on tab change (to support router tree updates while that tab is open).

The one thing I saw was some intermittent issues (not rendered properly) when multiple `RouterTree` messages are sent initially. I'm looking further into that, but if anyone has any thoughts, let me know. As a soft workaround I make sure it also triggers an `Input` change on tab switching, so switching away and back will give it another try.

The remaining work required is to support partial router tree updates as the component tree does, which I'm taking a stab at now.