### PR TITLE
Resolve issue with KeyRegistry blowing up on applications with weird ES6 shims

### DIFF
--- a/src/communication/message-factory.ts
+++ b/src/communication/message-factory.ts
@@ -1,5 +1,3 @@
-import {DebugElement} from '@angular/core';
-
 import {
   Message,
   MessageResponse,

--- a/src/tree/metadata.ts
+++ b/src/tree/metadata.ts
@@ -1,5 +1,3 @@
-import {EventEmitter} from '@angular/core';
-
 import {
   AsyncSubject,
   BehaviorSubject,
@@ -67,7 +65,7 @@ const loadMetadata =
 
   if (instance != null && isScalar(instance) === false) {
     switch (functionName(instance.constructor)) {
-      case functionName(EventEmitter):
+      case 'EventEmitter':
         flags |= PropertyMetadata.EventEmitter;
         break;
       case functionName(AsyncSubject):

--- a/src/tree/mutable-tree-factory.ts
+++ b/src/tree/mutable-tree-factory.ts
@@ -1,5 +1,3 @@
-import {DebugElement} from '@angular/core';
-
 import {MutableTree} from './mutable-tree';
 import {transform} from './transformer';
 import {Node} from './node';
@@ -31,7 +29,7 @@ export interface ElementTransformResult {
 }
 
 export const createTreeFromElements =
-    (roots: Array<DebugElement>, options: SimpleOptions): ElementTransformResult => {
+    (roots: Array<any /* DebugElement */>, options: SimpleOptions): ElementTransformResult => {
   const tree = new MutableTree();
 
   /// Keep track of the number of nodes that we process as part of this transformation


### PR DESCRIPTION
This PR resolves issues with sites like Asana.com which include weird ES6 shim implementations. Essentially this change prevents inclusion of Angular2 code before the ng-validate gate has been passed. (Prior to this change, Angular2 would be included as part of the dependency tree of ng-validate and caused exceptions on sites that use nonstandard ES6 shim implementations.) 