### PR TITLE
Decorators revamp part 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
     "basscss-layout": "^3.1.0",
     "clone": "^1.0.2",
     "css-loader": "^0.21.0",
-    "es6-promise": "^3.1.2",
-    "es6-shim": "^0.35.0",
     "file-loader": "^0.8.5",
     "msgpack-lite": "^0.1.20",
     "object-assign": "4.0.1",

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -224,10 +224,7 @@ const getComponentInstance = (tree: MutableTree, node: Node) => {
   if (node) {
     const probed = ng.probe(node.nativeElement());
     if (probed) {
-      return instanceWithMetadata(
-        probed.componentInstance,
-        new Set<string>(node.input.map(binding => binding.replace(/:(.*)$/, ''))),
-        new Set<string>(node.output));
+      return instanceWithMetadata(probed.componentInstance);
     }
   }
   return null;

--- a/src/communication/message-factory.ts
+++ b/src/communication/message-factory.ts
@@ -51,7 +51,7 @@ export abstract class MessageFactory {
   }
 
   static ping(): Message<void> {
-    return create({
+    return completeMessage<void>({
       messageType: MessageType.Ping,
     });
   }

--- a/src/frontend/components/component-info/component-info.ts
+++ b/src/frontend/components/component-info/component-info.ts
@@ -43,21 +43,22 @@ export class ComponentInfo {
 
   ngOnChanges() {
     if (this.node) {
+      const decorators = this.node.decorators;
       this.path = deserializePath(this.node.id);
-
-      const listenerNames = {};
-      for (const listener of this.node.listeners) {
-        listenerNames[listener.name] = 1;
-      }
 
       this.inputs = {};
       this.outputs = {};
-      for (const input of this.node.input) {
-        const [name, alias] = input.split(/:/);
-        if (listenerNames[name]) {
-          this.outputs[name] = {alias};
-        } else {
-          this.inputs[name] = {alias};
+
+      for (const k of Object.keys(decorators)) {
+        for (const decorator of decorators[k]) {
+          switch (decorator.name) {
+          case '@Input':
+            this.inputs[k] = {alias: decorator.arg};
+            break;
+          case '@Output':
+            this.outputs[k] = {alias: decorator.arg};
+            break;
+          }
         }
       }
     }

--- a/src/frontend/components/property-editor/property-editor.html
+++ b/src/frontend/components/property-editor/property-editor.html
@@ -1,7 +1,7 @@
 <div [ngClass]="{'property-editor': true, editing: state === State.Write}" (click)="onClick($event)">
   <span class="info-key">
     <div class="expander transparent"></div>
-    <span *ngIf="isInput" class="primary-color decorator">
+    <span *ngIf="inputs[key]" class="primary-color decorator">
       @Input(<span class="info-value" *ngIf="inputs[key] && inputs[key].alias">'{{inputs[key].alias}}'</span>)
     </span>
     {{key}}:

--- a/src/frontend/components/property-editor/property-editor.ts
+++ b/src/frontend/components/property-editor/property-editor.ts
@@ -76,15 +76,10 @@ export class PropertyEditor {
     }
   }
 
-  private get isInput(): boolean {
-    return (this.metadata & PropertyMetadata.Input) !== 0;
-  }
-
   private parseValue(value): EditorResult {
     try {
       return new Function(`return ${value}`)();
-    }
-    catch (e) {
+    } catch (e) {
       return value;
     }
   }

--- a/src/tree/metadata.ts
+++ b/src/tree/metadata.ts
@@ -15,11 +15,9 @@ import {
 import {functionName} from '../utils';
 
 export enum PropertyMetadata {
-  Input         = 0x1,
-  Output        = 0x2,
-  Subject       = 0x4,
-  Observable    = 0x8,
-  EventEmitter  = 0x10,
+  Subject       = 0b001,
+  Observable    = 0b010,
+  EventEmitter  = 0b100,
 }
 
 export type Metadata = Map<any, PropertyMetadata>;
@@ -29,13 +27,12 @@ export interface InstanceValue {
   metadata: any | Metadata;
 }
 
-export const instanceWithMetadata =
-    (instance, inputs: Set<string>, outputs: Set<string>): InstanceValue => {
+export const instanceWithMetadata = (instance): InstanceValue => {
   const map = new Map<any, PropertyMetadata>();
 
   if (instance != null) {
     for (const key of Object.keys(instance)) {
-      loadMetadata(inputs, outputs, instance[key], key, map);
+      loadMetadata(instance[key], key, map);
     }
   }
 
@@ -55,8 +52,7 @@ export const instanceWithMetadata =
   return {instance, metadata: metadataArray};
 };
 
-const loadMetadata =
-    (inputs: Set<string>, outputs: Set<string>, instance, top: string, map: Metadata) => {
+const loadMetadata = (instance, top: string, map: Metadata) => {
   if (map.has(instance)) {
     return;
   }
@@ -85,22 +81,12 @@ const loadMetadata =
           map.set(instance, flags);
 
           if (map.has(value) === false) {
-            loadMetadata(inputs, outputs, value, null, map);
+            loadMetadata(value, null, map);
           }
         }
         break;
     }
   }
-
-  if (top) {
-    if (inputs.has(top)) {
-      flags |= PropertyMetadata.Input;
-    }
-    else if (outputs.has(top)) {
-      flags |= PropertyMetadata.Output;
-    }
-  }
-
   map.set(instance, flags);
 };
 

--- a/src/tree/node.ts
+++ b/src/tree/node.ts
@@ -5,32 +5,27 @@ export interface EventListener {
   callback: Function;
 }
 
-export interface Node {
-  id: string;
-  isComponent: boolean;
-  changeDetection: string;
-  description: Array<Property>;
-  nativeElement: () => HTMLElement; // null on frontend
-  listeners: Array<EventListener>;
-  dependencies: Array<string>;
-  directives: Array<string>;
-  injectors: Array<string>;
-  providers: Array<Property>;
-  input: Array<string>;
-  output: Array<string>;
-  source: string;
+export interface DecoratorDisplay {
   name: string;
+  arg?: any;
+}
+
+export interface DecoratorDisplayMap {
+  [key: string]: Array<DecoratorDisplay>;
+}
+
+export interface Node {
+  changeDetection: string;
   children: Array<Node>;
-  properties: {
-      [key: string]: any;
-  };
-  attributes: {
-      [key: string]: string;
-  };
-  classes: {
-      [key: string]: boolean;
-  };
-  styles: {
-      [key: string]: string;
-  };
+  decorators: DecoratorDisplayMap;
+  dependencies: Array<string>;
+  description: Array<Property>;
+  directives: Array<string>;
+  id: string;
+  injectors: Array<string>;
+  isComponent: boolean;
+  listeners: Array<EventListener>;
+  name: string;
+  nativeElement: () => HTMLElement; // null on frontend
+  providers: Array<Property>;
 }

--- a/src/tree/transformer.ts
+++ b/src/tree/transformer.ts
@@ -19,9 +19,21 @@ import {
   SimpleOptions,
 } from '../options';
 
-import {Node} from './node';
-import {Path, serializePath} from './path';
-import {functionName, serialize} from '../utils';
+import {
+  DecoratorDisplay,
+  DecoratorDisplayMap,
+  Node,
+} from './node';
+
+import {
+  Path,
+  serializePath,
+} from './path';
+
+import {
+  functionName,
+  serialize,
+} from '../utils';
 
 type Source = DebugElement & DebugNode;
 
@@ -33,32 +45,18 @@ type Cache = Map<string, any>;
 /// in order for our tree comparisons to work. If we just create a reference to
 /// the existing DebugElement data, that data will mutate over time and
 /// invalidate the results of our comparison operations.
-export const transform = (
-    path: Path,
-    element: Source,
-    cache: Cache,
-    options: SimpleOptions,
-    count: (n: number) => void): Node => {
+export const
+transform = (path: Path, element: Source, cache: Cache, options: SimpleOptions, count: (n: number) => void): Node => {
   if (element == null) {
     return null;
   }
 
-  const load = <T>(key: string, creator: () => T) => {
-    if (key == null) {
-      return null;
-    }
-
-    let value = cache.get(key);
-    if (value == null) {
-      value = creator();
-    }
-
-    return value;
-  };
-
   const serializedPath = serializePath(path);
 
-  return load<Node>(serializedPath, () => {
+  const value = cache.get(serializedPath);
+  if (value != null) {
+    return value;
+  } else {
     const key = (subkey: string) => serializePath(path.concat([subkey]));
 
     const listeners = element.listeners.map(l => clone(l));
@@ -67,11 +65,9 @@ export const transform = (
       if (element.componentInstance &&
           element.componentInstance.constructor) {
         return functionName(element.componentInstance.constructor);
-      }
-      else if (element.name) {
+      } else if (element.name) {
         return element.name;
-      }
-      else {
+      } else {
         return element.nativeElement.tagName.toLowerCase();
       }
     })();
@@ -83,8 +79,7 @@ export const transform = (
         return [];
       }
 
-      const parameters = Reflect.getOwnMetadata('design:paramtypes',
-        element.componentInstance.constructor) || [];
+      const parameters = Reflect.getOwnMetadata('design:paramtypes', element.componentInstance.constructor) || [];
 
       return parameters.map(param => functionName(param));
     };
@@ -93,58 +88,28 @@ export const transform = (
 
     const isComponent = element.componentInstance != null;
 
-    const metadata = isComponent
-      ? getMetadata(element)
-      : null;
+    const metadata = isComponent ? getMetadata(element) : null;
 
-    const changeDetection = isComponent
-      ? ChangeDetectionStrategy[getChangeDetection(metadata)]
-      : null;
+    const changeDetection = isComponent ? ChangeDetectionStrategy[getChangeDetection(metadata)] : null;
 
-    const input = isComponent
-      ? getComponentInputs(metadata, element)
-      : [];
+    const decorators = isComponent ? getComponentDecorators(metadata, element) : <DecoratorDisplayMap>{};
 
-    const output = isComponent
-      ? getComponentOutputs(metadata, element)
-      : [];
-
-    const directives = isComponent
-      ? getComponentDirectives(metadata)
-      : [];
-
-    const cloneAndTransform = object => {
-      const copy = clone(object);
-
-      for (const k of Object.keys(copy)) {
-        if (copy[k] === undefined) { // undefined values cause json patch to misbehave
-          delete copy[k];
-        }
-      }
-
-      return copy;
-    };
+    const directives = isComponent ? getComponentDirectives(metadata) : [];
 
     const node: Node = {
-      id: serializedPath,
-      isComponent,
-      attributes: cloneAndTransform(element.attributes),
-      children: null,
       changeDetection,
+      children: null,
+      decorators,
+      dependencies: dependencies(),
       description: Description.getComponentDescription(element),
       directives,
-      classes: cloneAndTransform(element.classes),
-      styles: cloneAndTransform(element.styles),
+      id: serializedPath,
       injectors,
-      input,
-      output,
-      name,
+      isComponent,
       listeners,
-      properties: cloneAndTransform(element.properties),
+      name,
+      nativeElement: () => element.nativeElement, // this will be null in the frontend
       providers,
-      dependencies: dependencies(),
-      source: element.source,
-      nativeElement: () => element.nativeElement // this will be null in the frontend
     };
 
     /// Set before we search for children so that the value is cached and the
@@ -154,43 +119,37 @@ export const transform = (
     node.children = [];
 
     const transformChildren = (children: Array<Source>) => {
-      let subindex = 0;
-
-      children.forEach(c =>
-          node.children.push(
-            transform(path.concat([subindex++]), c, cache, options, count)));
+      let i = 0;
+      for (const child of children) {
+        node.children.push(transform(path.concat([i++]), child, cache, options, count));
+      }
     };
 
-    const getChildren = (test: (compareElement: Source) => boolean): Array<Source> => {
-      const children = element.children.map(c => matchingChildren(c, test));
-
-      return children.reduce((previous, current) => previous.concat(current), []);
-    };
-
-    const childComponents = () => {
-      return getChildren(e => e.componentInstance != null);
-    };
-
-    const childHybridComponents = () => {
-      return getChildren(e => e.providerTokens && e.providerTokens.length > 0);
+    const transformMatchingChildren = (test: (compareElement: Source) => boolean) => {
+      let i = 0;
+      for (const child of element.children) {
+        for (const match of matchingChildren(child, test)) {
+          node.children.push(transform(path.concat([i++]), match, cache, options, count));
+        }
+      }
     };
 
     switch (options.componentView) {
-      case ComponentView.Hybrid:
-        transformChildren(childHybridComponents());
-        break;
-      case ComponentView.All:
-        transformChildren(element.children);
-        break;
-      case ComponentView.Components:
-        transformChildren(childComponents());
-        break;
+    case ComponentView.Hybrid:
+      transformMatchingChildren(e => e.providerTokens && !!e.providerTokens.length);
+      break;
+    case ComponentView.All:
+      transformChildren(element.children);
+      break;
+    case ComponentView.Components:
+      transformMatchingChildren(e => e.componentInstance != null);
+      break;
     }
 
     count(1 + node.children.length);
 
     return node;
-  });
+  }
 };
 
 export const recursiveSearch =
@@ -200,8 +159,7 @@ export const recursiveSearch =
   for (const c of children) {
     if (test(c)) {
       result.push(c);
-    }
-    else {
+    } else {
       Array.prototype.splice.apply(result,
         (<Array<any>> [result.length - 1, 0]).concat(recursiveSearch(c.children, test)));
     }
@@ -229,18 +187,16 @@ const getComponentProviders = (element: Source, name: string): Array<Property> =
 
     if (name) {
       return providers.filter(provider => provider.key !== name);
-    }
-    else {
+    } else {
       return providers;
     }
 };
 
 const getMetadata = (element: Source): Component => {
-  const annotations =
-    Reflect.getOwnMetadata('annotations', element.componentInstance.constructor);
+  const annotations = Reflect.getOwnMetadata('annotations', element.componentInstance.constructor);
   if (annotations) {
     for (const decorator of annotations) {
-      if (functionName(decorator.constructor) === functionName(Component)) {
+      if (functionName(decorator.constructor) === 'Component') {
         return decorator;
       }
     }
@@ -253,48 +209,43 @@ const getComponentDirectives = (metadata: Component): Array<string> => {
   return [];
 };
 
-const getComponentInputs = (metadata: Component, element: Source) => {
-  const inputs = metadata && metadata.inputs
-    ? metadata.inputs
-    : [];
-
-  eachProperty(element,
-    (key: string, meta) => {
-      if (functionName(meta.constructor) === functionName(Input) && inputs.indexOf(key) < 0) {
-        const property = meta.bindingPropertyName
-          ? `${key}:${meta.bindingPropertyName}`
-          : key;
-        inputs.push(property);
-      }
-    });
-
-  return inputs;
-};
-
-const getComponentOutputs = (metadata: Component, element: Source): Array<string> => {
- const outputs = metadata && metadata.outputs
-    ? metadata.outputs
-    : [];
-
-  eachProperty(element,
-    (key: string, meta) => {
-      if (functionName(meta.constructor) === functionName(Output) && outputs.indexOf(key) < 0) {
-        outputs.push(key);
-      }
-    });
-
-  return outputs;
-};
-
-const eachProperty = (element: Source, fn: (key: string, decorator) => void) => {
+const getComponentDecorators = (metadata: Component, element: Source) => {
+  const decorators: DecoratorDisplayMap = {};
   const propMetadata = Reflect.getOwnMetadata('propMetadata', element.componentInstance.constructor);
+
   if (propMetadata) {
     for (const key of Object.keys(propMetadata)) {
+      const accum = decorators[key] = [];
       for (const meta of propMetadata[key]) {
-        fn(key, meta);
+        const name = meta.toString();
+        const dd: DecoratorDisplay = {
+          name: name,
+        };
+
+        switch (name) {
+        case '@Input':
+        case '@Output':
+          if (meta.bindingPropertyName) {
+            dd.arg = meta.bindingPropertyName;
+          }
+          break;
+        case '@Query':
+        case '@ViewQuery':
+        case '@ViewChild':
+        case '@ViewChildren':
+          /* This is not technically complete,
+           * as there is an optional second parameter
+           * to some of these Decorators. */
+          dd.arg = meta.selector;
+          break;
+        }
+
+        accum.push(dd);
       }
     }
   }
+
+  return decorators;
 };
 
 const getChangeDetection = (metadata: Component): ChangeDetectionStrategy => {

--- a/src/tree/transformer.ts
+++ b/src/tree/transformer.ts
@@ -25,7 +25,7 @@ import {functionName, serialize} from '../utils';
 
 type Source = DebugElement & DebugNode;
 
-type Cache = WeakMap<any, any>;
+type Cache = Map<string, any>;
 
 /// Transform a {@link DebugElement} or {@link DebugNode} element into a Node
 /// object that is our local representation of the combined data of those two

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compileOnSave": false,
   "buildOnSave": false,
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "declaration": false,
     "noImplicitAny": false,

--- a/typings.json
+++ b/typings.json
@@ -3,7 +3,6 @@
   "ambientDependencies": {
     "MediaStream": "github:DefinitelyTyped/DefinitelyTyped/webrtc/MediaStream.d.ts#62eedc3121a5e28c50473d2e4a9cefbcb9c3957f",
     "chrome": "github:DefinitelyTyped/DefinitelyTyped/chrome/chrome.d.ts#62eedc3121a5e28c50473d2e4a9cefbcb9c3957f",
-    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#4de74cb527395c13ba20b438c3a7a419ad931f1c",
     "filesystem": "github:DefinitelyTyped/DefinitelyTyped/filesystem/filesystem.d.ts#62eedc3121a5e28c50473d2e4a9cefbcb9c3957f",
     "filewriter": "github:DefinitelyTyped/DefinitelyTyped/filewriter/filewriter.d.ts#62eedc3121a5e28c50473d2e4a9cefbcb9c3957f",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#263705d313346e093d95cb62cef6fed848e46978",
@@ -14,7 +13,6 @@
     "chrome": "registry:dt/chrome#0.0.0+20160724063844",
     "clone": "registry:dt/clone#0.1.11+20160317120654",
     "d3": "registry:dt/d3#0.0.0+20160727131401",
-    "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504",
     "filesystem": "registry:dt/filesystem#0.0.0+20160316155526",
     "filewriter": "registry:dt/filewriter#0.0.0+20160316155526",
     "node": "registry:dt/node#6.0.0+20160823142437",


### PR DESCRIPTION
This is not totally finished, it turns out there is some work required to support certain groups of decorators properly. The changes in this PR fix detection of the currently supported `@Input` and `@Output` decorators which were previously incorrect. I will publish a separate PR which expands to support multiple decorators on a single member, and all of the core Angular Decorators.

This PR also includes a switch to ES6 codegen in typescript, which works perfectly fine in Chromes released in the last 12 months or so, and makes it much easier to debug the generated code since there is less mangling.

In addition, I have also removed some properties on Node which are no longer used, and the code that attaches them.
