### PR TITLE
On push property change detect

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -253,6 +253,12 @@ const updateProperty = (tree: MutableTree, path: Path, newValue) => {
       const instanceParent = getNodeInstanceParent(probed, path);
       if (instanceParent) {
         instanceParent[path[path.length - 1]] = newValue;
+        if (node.changeDetection === 'OnPush') {
+          probed.childNodes.map(childNode => {
+            childNode._debugInfo._view.changeDetectorRef.markForCheck();
+            childNode._debugInfo._view.changeDetectorRef.detectChanges();
+          });
+        }
       }
     }
   }

--- a/src/tree/transformer.ts
+++ b/src/tree/transformer.ts
@@ -298,9 +298,11 @@ const eachProperty = (element: Source, fn: (key: string, decorator) => void) => 
 };
 
 const getChangeDetection = (metadata: Component): ChangeDetectionStrategy => {
-   if (metadata == null ||
-       metadata.changeDetection == null) {
-     return ChangeDetectionStrategy.Default;
+  if (metadata &&
+    metadata.changeDetection !== undefined &&
+    metadata.changeDetection !== null) {
+    return metadata.changeDetection;
+  } else {
+    return ChangeDetectionStrategy.Default;
   }
-  return metadata.changeDetection;
 };


### PR DESCRIPTION
resolves #559 

This calls `markForCheck()` and `checkForUpdates()` for all properties on an `ChangeDetection.OnPush` component, when a property is updated, as well as fixes an issue with resolving the ChangeDetectionStrategy (when it's `OnPush`).