### PR TITLE
Resolve performance issue due to bug in which JSON patch library is not able to compare `undefined` values

### DIFF
--- a/src/utils/patch.test.ts
+++ b/src/utils/patch.test.ts
@@ -1,0 +1,56 @@
+import * as test from 'tape';
+
+import {compare} from './patch';
+
+test('utils/patch: JSON patch should deal gracefully with undefined values', t => {
+  t.plan(3);
+
+  const obj1 = {a: 'foo', b: undefined};
+  const obj2 = {a: 'foo', b: undefined};
+
+  const changes = compare(obj1, obj2);
+
+  t.ok(changes, 'changes is not null');
+  t.ok(Array.isArray(changes), 'changes is an array');
+  t.notOk(changes.length, 'objects should compare as identical');
+
+  t.end();
+});
+
+test('utils/patch: JSON patch can generate a changeset for simple objects', t => {
+  t.plan(5);
+
+  const obj1 = {a: 'foo', b: 'bar'};
+  const obj2 = {a: 'foo', b: 'foo'};
+
+  const changes = compare(obj1, obj2);
+
+  t.ok(changes, 'changes is not null');
+  t.ok(Array.isArray(changes), 'changes is an array');
+  t.equals(1, changes.length, 'changes should contain one change');
+  t.equals('replace', changes[0].op, 'operation should be a "replace" op');
+  t.equals('/b', changes[0].path, 'paths should point to "b" property');
+
+  t.end();
+});
+
+test('utils/patch: JSON patch can generate a changeset for nested objects', t => {
+  t.plan(8);
+
+  const obj1 = {a: 'foo', b: {fizz: 'bar'}};
+  const obj2 = {a: 'foo', b: {fozz: 'bar'}};
+
+  const changes = compare(obj1, obj2);
+
+  t.ok(changes, 'changes is not null');
+  t.ok(Array.isArray(changes), 'changes is an array');
+  t.equals(2, changes.length, 'changes should contain two changes');
+  t.equals('remove', changes[0].op, 'first operation should be a "remove" op');
+  t.equals('/b/fizz', changes[0].path, 'first operation should delete "/b/fizz"');
+  t.equals('add', changes[1].op, 'second operation should be an "add" op');
+  t.equals('/b/fozz', changes[1].path, 'second operation should add "/b/fozz"');
+  t.equals('bar', changes[1].value, 'second operation should have a value of "bar"');
+
+  t.end();
+});
+

--- a/src/utils/patch.ts
+++ b/src/utils/patch.ts
@@ -13,8 +13,8 @@ function equals(a, b) {
     case 'number':
       return a === b;
     case 'object':
-      if (a === null) {
-        return b === null;
+      if (a == null) {
+        return b == null;
       }
       if (Array.isArray(a)) {
         if (!Array.isArray(b) || a.length !== b.length) {
@@ -212,22 +212,6 @@ export function apply(tree, patches: Array<any>, validate?: boolean): Array<any>
   return results;
 }
 
-function hasUndefined(obj): boolean {
-  if (obj === undefined) {
-      return true;
-  }
-
-  if (typeof obj === 'array' || typeof obj === 'object') {
-    for (const i in obj) {
-      if (hasUndefined(obj[i])) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
 function escapePathComponent (str) {
   if (str.indexOf('/') < 0 &&
       str.indexOf('~') < 0) {
@@ -247,21 +231,26 @@ function generatePatch(mirror, obj, patches, path) {
     const key = oldKeys[t];
     const oldVal = mirror[key];
 
-    if (obj.hasOwnProperty(key) && !(obj[key] === undefined && Array.isArray(obj) === false)) {
+    if (obj.hasOwnProperty(key) && !(obj[key] == null && Array.isArray(obj) === false)) {
       const newVal = obj[key];
       if (typeof oldVal === 'object' && oldVal != null && typeof newVal === 'object' && newVal != null) {
         generatePatch(oldVal, newVal, patches, path + '/' + escapePathComponent(key));
       }
       else {
-        if (oldVal !== newVal) {
+        if (oldVal == null && newVal == null) {
+          continue;
+        }
+        else if (oldVal !== newVal) {
           changed = true;
           patches.push({op: 'replace', path: path + '/' + escapePathComponent(key), value: newVal});
         }
       }
     }
     else {
-      patches.push({op: 'remove', path: path + '/' + escapePathComponent(key)});
-      deleted = true; // property has been deleted
+      if (oldVal != null) {
+        patches.push({op: 'remove', path: path + '/' + escapePathComponent(key)});
+        deleted = true; // property has been deleted
+      }
     }
   }
 


### PR DESCRIPTION
* Resolve bug in which JSON patch library is not able to compare `undefined` values properly.  In turn, this resolves a major performance issue where Augury was generating endless 'changes' even when nothing changed, if there was an `undefined` value somewhere in the tree structure.
* Add unit tests to cover this case and verify that the patch library continues to work as expected for non-undefined values