### PR TITLE
Improve AoT readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ export default class KitchenSink {
 In order for Angular to expose the debug information for AoT applications, you will have to explicitly set the debug flag to `true` in your project's `tsconfig.json` as such:
 ```json
 "angularCompilerOptions": {
+  /* ... */
   "debug": true
 }
 ```


### PR DESCRIPTION
I've added this comment line to indicate that other options are required in the `angularCompilerOptions` section, because without the `genDir` property, Augury will break.