### PR TITLE
It seems that changes to bindings in ngDoCheck require another

### DIFF
--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -119,6 +119,7 @@ class App {
 
   private ngDoCheck() {
     this.selectedNode = this.viewState.selectedTreeNode(this.tree);
+    this.changeDetector.detectChanges();
   }
 
   private ngOnInit() {


### PR DESCRIPTION
round of change detection triggered.

Otherwise, an exception is thrown by Angular in dev mode that
the expression was changed after change detection