### PR TITLE
Add min-width to "Search Components" input

### DIFF
--- a/src/frontend/components/tree-view/tree-view.html
+++ b/src/frontend/components/tree-view/tree-view.html
@@ -11,7 +11,7 @@
     </component-tree>
   </div>
   <div class="bg-panel border-top">
-    <header class="flex py1 px2">
+    <header class="flex py1 px2 minwidth-100pct">
       <search
          (selectedResult)="onSelectedSearchResultChanged($event)"
          [handler]="onRetrieveSearchResults"


### PR DESCRIPTION
This adds a min-width to search component, so while it maintains the expansion to fit at larger sizes, it won't ever compress enough to screw up the layout of the icon and input.

<img width="398" alt="screen shot 2016-11-03 at 3 19 48 pm" src="https://cloud.githubusercontent.com/assets/898763/19972351/a8542458-a1d9-11e6-90ef-910974ad9425.png">

resolves #676 