### PR TITLE
Add support for @ViewChild, @ViewChildren, @ContentChild and @ContentChildren decorators in state view

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",
     "file-loader": "^0.8.5",
+    "md5": "^2.2.1",
     "msgpack-lite": "^0.1.20",
     "object-assign": "4.0.1",
     "postcss-cssnext": "^2.5.2",

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -224,10 +224,7 @@ const getComponentInstance = (tree: MutableTree, node: Node) => {
   if (node) {
     const probed = ng.probe(node.nativeElement());
     if (probed) {
-      return instanceWithMetadata(
-        probed.componentInstance,
-        new Set<string>(node.input.map(binding => binding.replace(/:(.*)$/, ''))),
-        new Set<string>(node.output));
+      return instanceWithMetadata(node, probed.componentInstance);
     }
   }
   return null;

--- a/src/frontend/components/component-info/component-info.html
+++ b/src/frontend/components/component-info/component-info.html
@@ -68,8 +68,6 @@
             <template [ngSwitchCase]="ComponentLoadState.Received">
               <bt-render-state
                  [id]="node.id"
-                 [inputs]="inputs"
-                 [outputs]="outputs"
                  [metadata]="metadata"
                  [level]="0"
                  [path]="path"

--- a/src/frontend/components/component-info/component-info.ts
+++ b/src/frontend/components/component-info/component-info.ts
@@ -35,7 +35,7 @@ export class ComponentInfo {
 
   private path: Path;
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges() {
     if (this.node) {
       this.path = deserializePath(this.node.id);
     }

--- a/src/frontend/components/component-info/component-info.ts
+++ b/src/frontend/components/component-info/component-info.ts
@@ -3,10 +3,11 @@ import {
   EventEmitter,
   Input,
   Output,
+  SimpleChanges,
 } from '@angular/core';
 
 import {ComponentLoadState} from '../../state';
-import {InputOutput} from '../../../frontend/utils';
+
 import {UserActions} from '../../actions/user-actions/user-actions';
 
 import {
@@ -22,44 +23,21 @@ import {
   template: require('./component-info.html'),
 })
 export class ComponentInfo {
-  @Input() node: Node;
-  @Input() tree: MutableTree;
-  @Input() state;
-  @Input() metadata: Metadata;
-  @Input() loadingState: ComponentLoadState;
+  @Input() private node: Node;
+  @Input() private tree: MutableTree;
+  @Input() private state;
+  @Input() private metadata: Metadata;
+  @Input() private loadingState: ComponentLoadState;
 
   @Output() private selectNode = new EventEmitter<Node>();
 
   private ComponentLoadState = ComponentLoadState;
 
-  path: Path;
+  private path: Path;
 
-  inputs: InputOutput;
-  outputs: InputOutput;
-
-  ngOnInit() {
-    this.ngOnChanges();
-  }
-
-  ngOnChanges() {
+  ngOnChanges(changes: SimpleChanges) {
     if (this.node) {
       this.path = deserializePath(this.node.id);
-
-      const listenerNames = {};
-      for (const listener of this.node.listeners) {
-        listenerNames[listener.name] = 1;
-      }
-
-      this.inputs = {};
-      this.outputs = {};
-      for (const input of this.node.input) {
-        const [name, alias] = input.split(/:/);
-        if (listenerNames[name]) {
-          this.outputs[name] = {alias};
-        } else {
-          this.inputs[name] = {alias};
-        }
-      }
     }
   }
 

--- a/src/frontend/components/info-panel/info-panel.ts
+++ b/src/frontend/components/info-panel/info-panel.ts
@@ -9,10 +9,11 @@ import {ComponentLoadState} from '../../state';
 import {StateTab} from '../../state';
 import {UserActions} from '../../actions/user-actions/user-actions';
 import {
-  InstanceValue,
+  InstanceWithMetadata,
   Metadata,
   Node,
-  PropertyMetadata,
+  ObjectType,
+  Path,
 } from '../../../tree';
 
 @Component({
@@ -22,7 +23,7 @@ import {
 export class InfoPanel {
   @Input() tree;
   @Input() node;
-  @Input() instanceValue: InstanceValue;
+  @Input() instanceValue: InstanceWithMetadata;
   @Input() loadingState: ComponentLoadState;
 
   @Output() private selectNode = new EventEmitter<Node>();
@@ -51,11 +52,9 @@ export class InfoPanel {
   }
 
   private get metadata(): Metadata {
-    if (this.instanceValue) {
-      return this.instanceValue.metadata;
-    }
-
-    return new Map<string, PropertyMetadata>();
+    return this.instanceValue
+      ? this.instanceValue.metadata
+      : new Map<string, [ObjectType, any]>();
   }
 
   private onSelectedTabChanged(tab: StateTab) {

--- a/src/frontend/components/property-editor/property-editor.html
+++ b/src/frontend/components/property-editor/property-editor.html
@@ -1,11 +1,4 @@
 <div [ngClass]="{'property-editor': true, editing: state === State.Write}" (click)="onClick($event)">
-  <span class="info-key">
-    <div class="expander transparent"></div>
-    <span *ngIf="isInput" class="primary-color decorator">
-      @Input(<span class="info-value" *ngIf="inputs[key] && inputs[key].alias">'{{inputs[key].alias}}'</span>)
-    </span>
-    {{key}}:
-  </span>
   <span [ngSwitch]="state" class="state-container">
     <span *ngSwitchCase="State.Read">
       <span class="editable">

--- a/src/frontend/components/property-editor/property-editor.ts
+++ b/src/frontend/components/property-editor/property-editor.ts
@@ -32,9 +32,8 @@ export enum State {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PropertyEditor {
-  @Input() key: string;
-  @Input() level: number;
-  @Input() metadata: ObjectType;
+  @Input() private key: string;
+  @Input() private level: number;
   @Input() private initialValue;
 
   @Output() private cancel = new EventEmitter<void>();
@@ -72,10 +71,6 @@ export class PropertyEditor {
     if (this.state === State.Write) {
       this.focus();
     }
-  }
-
-  private get isInput(): boolean {
-    return (this.metadata & ObjectType.Input) !== 0;
   }
 
   private parseValue(value): EditorResult {

--- a/src/frontend/components/property-editor/property-editor.ts
+++ b/src/frontend/components/property-editor/property-editor.ts
@@ -9,10 +9,9 @@ import {
   Output,
 } from '@angular/core';
 
-import {InputOutput} from '../../utils';
 import {Highlightable} from '../../utils/highlightable';
 import {highlightTime} from '../../../utils/configuration';
-import {PropertyMetadata} from '../../../tree';
+import {ObjectType} from '../../../tree';
 
 /// The types of values that this editor can emit to its owner
 export type EditorType = string | number | Object | Function;
@@ -35,8 +34,7 @@ export enum State {
 export class PropertyEditor {
   @Input() key: string;
   @Input() level: number;
-  @Input() inputs: InputOutput;
-  @Input() metadata: PropertyMetadata;
+  @Input() metadata: ObjectType;
   @Input() private initialValue;
 
   @Output() private cancel = new EventEmitter<void>();
@@ -77,7 +75,7 @@ export class PropertyEditor {
   }
 
   private get isInput(): boolean {
-    return (this.metadata & PropertyMetadata.Input) !== 0;
+    return (this.metadata & ObjectType.Input) !== 0;
   }
 
   private parseValue(value): EditorResult {

--- a/src/frontend/components/render-state/render-state.html
+++ b/src/frontend/components/render-state/render-state.html
@@ -4,9 +4,7 @@
   <span *ngIf="none">
     No state to show
   </span>
-  <span class="property-container"
-     (click)="expandTree(k, $event)"
-     *ngIf="nest(k)">
+  <span class="property-container" (click)="expandTree(k, $event)">
     <span class="info-key" [ngClass]="{output: isEmittable(k)}">
       <div [ngClass]="{
         expander: true,
@@ -14,11 +12,23 @@
         transparent: !expandable(k)
       }"></div>
       <span class="primary-color">
-        <span *ngIf="level === 0 && inputs[k]" class="decorator">
-          @Input(<span class="info-value" *ngIf="inputs[k] && inputs[k].alias">'{{inputs[k].alias}}'</span>)
+        <span *ngIf="isObjectType(k, ObjectType.Input)" class="decorator">
+          @Input(<span class="info-value" *ngIf="getAlias(k)">'{{getAlias(k)}}'</span>)
         </span>
-        <span *ngIf="level === 0 && outputs[k]" class="decorator">
-          @Output(<span class="info-value" *ngIf="outputs[k] && outputs[k].alias">'{{outputs[k].alias}}'</span>)
+        <span *ngIf="isObjectType(k, ObjectType.Output)" class="decorator">
+          @Output(<span class="info-value" *ngIf="getAlias(k)">'{{getAlias(k)}}'</span>)
+        </span>
+        <span *ngIf="isObjectType(k, ObjectType.ViewChild)" class="decorator">
+          @ViewChild({{getSelector(k)}})
+        </span>
+        <span *ngIf="isObjectType(k, ObjectType.ViewChildren)" class="decorator">
+          @ViewChildren({{getSelector(k)}})
+        </span>
+        <span *ngIf="isObjectType(k, ObjectType.ContentChild)" class="decorator">
+          @ContentChild({{getSelector(k)}})
+        </span>
+        <span *ngIf="isObjectType(k, ObjectType.ContentChildren)" class="decorator">
+          @ContentChildren({{getSelector(k)}})
         </span>
       </span>
       {{k}}:
@@ -34,18 +44,17 @@
         Emit
       </button>
     </span>
-    <span *ngIf="!isEmittable(k)" class="info-value">
+    <span *ngIf="!isEmittable(k) && nest(k)" class="info-value">
       {{displayType(k)}}
     </span>
+    <bt-state-values
+      *ngIf="!isEmittable(k) && !nest(k)"
+      [id]="id"
+      [metadata]="metadata"
+      [path]="path.concat([k])"
+      [value]="state[k]">
+    </bt-state-values>
   </span>
-  <bt-state-values
-     *ngIf="nest(k) === false"
-     [id]="id"
-     [inputs]="inputs"
-     [metadata]="metadataForKey(k)"
-     [path]="path.concat([k])"
-     [value]="state[k]">
-  </bt-state-values>
   <div *ngIf="expanded(k)">
     <bt-render-state
        *ngIf="nest(k)"

--- a/src/frontend/components/state-values/state-values.html
+++ b/src/frontend/components/state-values/state-values.html
@@ -1,7 +1,6 @@
 <div [ngClass]="{changed: isUpdated, property: true}">
   <bt-property-editor
      [key]="key"
-     [metadata]="metadata"
      [initialValue]="value"
      (submit)="onValueChanged($event)">
   </bt-property-editor>

--- a/src/frontend/components/state-values/state-values.html
+++ b/src/frontend/components/state-values/state-values.html
@@ -1,7 +1,6 @@
 <div [ngClass]="{changed: isUpdated, property: true}">
   <bt-property-editor
      [key]="key"
-     [inputs]="inputs"
      [metadata]="metadata"
      [initialValue]="value"
      (submit)="onValueChanged($event)">

--- a/src/frontend/components/state-values/state-values.ts
+++ b/src/frontend/components/state-values/state-values.ts
@@ -6,11 +6,10 @@ import {
 
 import {UserActions} from '../../actions/user-actions/user-actions';
 import {Highlightable} from '../../utils/highlightable';
-import {InputOutput} from '../../utils';
 import {functionName} from '../../../utils';
 import {
   Path,
-  PropertyMetadata,
+  ObjectType,
   Metadata,
 } from '../../../tree';
 
@@ -22,8 +21,7 @@ import {
 export class StateValues extends Highlightable {
   @Input() id: string | number;
   @Input() path: Path;
-  @Input() inputs: InputOutput;
-  @Input() metadata: PropertyMetadata;
+  @Input() metadata: ObjectType;
   @Input() value;
 
   private editable: boolean = false;

--- a/src/frontend/state/component-instance-state.ts
+++ b/src/frontend/state/component-instance-state.ts
@@ -1,9 +1,9 @@
 import {ChangeDetectorRef} from '@angular/core';
 
 import {
-  InstanceValue,
+  InstanceWithMetadata,
   Metadata,
-  PropertyMetadata,
+  ObjectType,
   Node,
 } from '../../tree';
 
@@ -16,7 +16,7 @@ export enum ComponentLoadState {
 class CachedValue {
   constructor(
     public state: ComponentLoadState,
-    public value: InstanceValue
+    public value: InstanceWithMetadata
   ) {}
 }
 
@@ -47,7 +47,7 @@ export class ComponentInstanceState {
     return (<CachedValue> cache).state;
   }
 
-  componentInstance(node: Node): InstanceValue {
+  componentInstance(node: Node): InstanceWithMetadata {
     if (node == null) {
       return null;
     }
@@ -70,13 +70,9 @@ export class ComponentInstanceState {
     }
   }
 
-  wait(node: Node, promise: Promise<InstanceValue>) {
+  wait(node: Node, promise: Promise<InstanceWithMetadata>) {
     promise.then(response => {
-      const metadata = toMap(response.metadata);
-
-      const value = {instance: response.instance, metadata};
-
-      this.map.set(node.id, new CachedValue(ComponentLoadState.Received, value));
+      this.map.set(node.id, new CachedValue(ComponentLoadState.Received, response));
 
       this.changeDetector.detectChanges();
     })
@@ -98,13 +94,3 @@ export class ComponentInstanceState {
     }
   }
 }
-
-const toMap = (array): Metadata => {
-  const map = new Map<any, PropertyMetadata>();
-
-  for (const item of array) {
-    map.set(item[0], item[1]);
-  }
-
-  return map;
-};

--- a/src/frontend/utils/index.ts
+++ b/src/frontend/utils/index.ts
@@ -1,4 +1,3 @@
-export * from './input-output';
 export * from './graph-utils';
 export * from './parse-data';
 export * from './parse-utils';

--- a/src/frontend/utils/input-output.ts
+++ b/src/frontend/utils/input-output.ts
@@ -1,3 +1,0 @@
-export interface InputOutput {
-  [key: string]: {alias: string};
-}

--- a/src/tree/decorators.ts
+++ b/src/tree/decorators.ts
@@ -1,0 +1,90 @@
+import {
+  Component,
+  DebugElement,
+} from '@angular/core';
+
+import {
+  InputProperty,
+  OutputProperty,
+} from './node';
+
+import {functionName} from '../utils';
+
+export const classDecorators = (instance): Array<any> =>
+  Reflect.getOwnMetadata('annotations', instance.constructor) || [];
+
+export const propertyDecorators = (instance): Array<any> =>
+  Reflect.getOwnMetadata('propMetadata', instance.constructor) || [];
+
+export const parameterTypes = (instance): Array<any> =>
+  Reflect.getOwnMetadata('design:paramtypes', instance.constructor) || [];
+
+export const iteratePropertyDecorators = (instance, fn: (key: string, decorator) => void) => {
+  if (instance == null) {
+    return;
+  }
+
+  const decorators = propertyDecorators(instance);
+
+  for (const key of Object.keys(decorators)) {
+    for (const meta of decorators[key]) {
+      fn(key, meta);
+    }
+  }
+};
+
+export const componentMetadata = (instance): Component => {
+  if (instance == null) {
+    return null;
+  }
+
+  return classDecorators(instance).find(d => functionName(d.constructor) === functionName(Component));
+};
+
+export const componentInputs = (metadata: Component, instance): Array<InputProperty> => {
+  const inputs: Array<InputProperty> =
+    ((metadata && metadata.inputs) || []).map(p => ({propertyKey: p}));
+
+  iteratePropertyDecorators(instance,
+    (key: string, meta) => {
+      if (inputs.find(i => i.propertyKey === key) == null) {
+        if (meta.toString() === '@Input') {
+          inputs.push({propertyKey: key, bindingPropertyName: meta.bindingPropertyName});
+        }
+      }
+    });
+
+  return inputs;
+};
+
+export const componentOutputs = (metadata: Component, instance): Array<OutputProperty> => {
+  const outputs: Array<OutputProperty> =
+    ((metadata && metadata.outputs) || []).map(p => ({propertyKey: p}));
+
+  iteratePropertyDecorators(instance,
+    (key: string, meta) => {
+      if (meta.toString() === '@Output') {
+        outputs.push({propertyKey: key, bindingPropertyName: meta.bindingPropertyName});
+      }
+    });
+
+  return Array.from(outputs);
+};
+
+export interface Query {
+  propertyKey: string;
+  selector: string;
+}
+
+export const componentQueryChildren = (type: string, metadata: Component, instance): Array<Query> => {
+  const queries = new Array<Query>();
+
+  iteratePropertyDecorators(instance,
+    (key: string, meta) => {
+      if (meta.toString() === type) {
+        queries.push({propertyKey: key, selector: functionName(meta.selector)});
+      }
+    });
+
+  return queries;
+};

--- a/src/tree/mutable-tree-factory.ts
+++ b/src/tree/mutable-tree-factory.ts
@@ -7,7 +7,7 @@ export const transformToTree =
     (root, index: number, options: SimpleOptions, increment: (n: number) => void) => {
   const map = new Map<string, Node>();
   try {
-    return transform([index], root, map, options, increment);
+    return transform([index], root, options, map, increment);
   }
   finally {
     map.clear(); // release references
@@ -29,7 +29,7 @@ export interface ElementTransformResult {
 }
 
 export const createTreeFromElements =
-    (roots: Array<any /* DebugElement */>, options: SimpleOptions): ElementTransformResult => {
+    (roots: Array<any>, options: SimpleOptions): ElementTransformResult => {
   const tree = new MutableTree();
 
   /// Keep track of the number of nodes that we process as part of this transformation

--- a/src/tree/node.ts
+++ b/src/tree/node.ts
@@ -5,6 +5,13 @@ export interface EventListener {
   callback: Function;
 }
 
+export interface InputProperty {
+  propertyKey: string;
+  bindingPropertyName?: string;
+}
+
+export interface OutputProperty extends InputProperty {} // outputs can be aliased too
+
 export interface Node {
   id: string;
   isComponent: boolean;
@@ -16,8 +23,8 @@ export interface Node {
   directives: Array<string>;
   injectors: Array<string>;
   providers: Array<Property>;
-  input: Array<string>;
-  output: Array<string>;
+  input: Array<InputProperty>;
+  output: Array<OutputProperty>;
   source: string;
   name: string;
   children: Array<Node>;

--- a/src/utils/circular-recurse.ts
+++ b/src/utils/circular-recurse.ts
@@ -1,0 +1,29 @@
+import {Path} from '../tree';
+
+export type Apply = (path: Path, value) => void;
+
+export const recurse = (initialPath: Path, object, exec: Apply) => {
+  const visited = new Set();
+
+  const apply = (path: Path, value, fn: Apply) => {
+    if (value == null || visited.has(value)) {
+      return;
+    }
+
+    visited.add(value);
+
+    fn(path, value);
+
+    if (Array.isArray(value) || value instanceof Set) {
+      (<any>value).forEach((v, k) => apply(path.concat([k]), v, fn));
+    }
+    else if (value instanceof Map) {
+      value.forEach((v, k) => apply(path.concat([k]), v, fn));
+    }
+    else {
+      Object.keys(value).forEach(k => apply(path.concat([k]), value[k], fn));
+    }
+  };
+
+  apply(initialPath, object, exec);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,7 @@
+export * from './circular-recurse';
 export * from './configuration';
 export * from './function-name';
 export * from './ng-validate';
+export * from './scalar';
 export * from './serialize';
 export * from './serialize-binary';

--- a/src/utils/scalar.ts
+++ b/src/utils/scalar.ts
@@ -1,0 +1,11 @@
+export const isScalar = value => {
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+    case 'function':
+    case 'undefined':
+      return true;
+    default:
+      return false;
+  }
+};

--- a/typings.json
+++ b/typings.json
@@ -17,6 +17,7 @@
     "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504",
     "filesystem": "registry:dt/filesystem#0.0.0+20160316155526",
     "filewriter": "registry:dt/filewriter#0.0.0+20160316155526",
+    "md5": "registry:dt/md5#2.1.0+20160521153251",
     "node": "registry:dt/node#6.0.0+20160823142437",
     "tape": "registry:dt/tape#4.2.2+20160317120654",
     "webrtc/mediastream": "registry:dt/webrtc/mediastream#0.0.0+20160317120654"


### PR DESCRIPTION
* Add support for @ViewChild, @ViewChildren, @ContentChild and @ContentChildren decorators in state view
* Refactor all 'inputs' and 'outputs' to use property metadata system so that they continue to work at all levels of the state tree, not just the toplevel (this is pertinent when using eg @ViewChild and the child component has @Input()s)

Screenshot:
![screen shot 2016-11-07 at 7 32 50 pm](https://cloud.githubusercontent.com/assets/1780164/20082101/c15955ae-a521-11e6-9a7f-f79255bf63e9.png)

