### PR TITLE
Display real type information in the State view instead of always "Object"

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "es6-promise": "^3.1.2",
     "es6-shim": "^0.35.0",
     "file-loader": "^0.8.5",
-    "md5": "^2.2.1",
     "msgpack-lite": "^0.1.20",
     "object-assign": "4.0.1",
     "postcss-cssnext": "^2.5.2",

--- a/src/frontend/components/component-info/component-info.html
+++ b/src/frontend/components/component-info/component-info.html
@@ -68,6 +68,7 @@
             <template [ngSwitchCase]="ComponentLoadState.Received">
               <bt-render-state
                  [id]="node.id"
+                 [componentMetadata]="componentMetadata"
                  [metadata]="metadata"
                  [level]="0"
                  [path]="path"

--- a/src/frontend/components/component-info/component-info.ts
+++ b/src/frontend/components/component-info/component-info.ts
@@ -11,6 +11,7 @@ import {ComponentLoadState} from '../../state';
 import {UserActions} from '../../actions/user-actions/user-actions';
 
 import {
+  ComponentMetadata,
   Metadata,
   MutableTree,
   Node,
@@ -27,6 +28,7 @@ export class ComponentInfo {
   @Input() private tree: MutableTree;
   @Input() private state;
   @Input() private metadata: Metadata;
+  @Input() private componentMetadata: ComponentMetadata;
   @Input() private loadingState: ComponentLoadState;
 
   @Output() private selectNode = new EventEmitter<Node>();

--- a/src/frontend/components/info-panel/info-panel.html
+++ b/src/frontend/components/info-panel/info-panel.html
@@ -9,6 +9,7 @@
   [tree]="tree"
   [loadingState]="loadingState"
   [state]="state"
+  [componentMetadata]="componentMetadata"
   [metadata]="metadata"
   [hidden]="selectedTab !== StateTab.Properties"
   [ngClass]="{flex: selectedTab === StateTab.Properties}"

--- a/src/frontend/components/info-panel/info-panel.ts
+++ b/src/frontend/components/info-panel/info-panel.ts
@@ -9,6 +9,7 @@ import {ComponentLoadState} from '../../state';
 import {StateTab} from '../../state';
 import {UserActions} from '../../actions/user-actions/user-actions';
 import {
+  ComponentMetadata,
   InstanceWithMetadata,
   Metadata,
   Node,
@@ -55,6 +56,12 @@ export class InfoPanel {
     return this.instanceValue
       ? this.instanceValue.metadata
       : new Map<string, [ObjectType, any]>();
+  }
+
+  private get componentMetadata(): ComponentMetadata {
+    return this.instanceValue
+      ? this.instanceValue.componentMetadata
+      : new Map<string, [string, ObjectType, any]>();
   }
 
   private onSelectedTabChanged(tab: StateTab) {

--- a/src/frontend/components/render-state/render-state.html
+++ b/src/frontend/components/render-state/render-state.html
@@ -12,22 +12,22 @@
         transparent: !expandable(k)
       }"></div>
       <span class="primary-color">
-        <span *ngIf="isObjectType(k, ObjectType.Input)" class="decorator">
+        <span *ngIf="isComponentObjectType(k, ObjectType.Input)" class="decorator">
           @Input(<span class="info-value" *ngIf="getAlias(k)">'{{getAlias(k)}}'</span>)
         </span>
-        <span *ngIf="isObjectType(k, ObjectType.Output)" class="decorator">
+        <span *ngIf="isComponentObjectType(k, ObjectType.Output)" class="decorator">
           @Output(<span class="info-value" *ngIf="getAlias(k)">'{{getAlias(k)}}'</span>)
         </span>
-        <span *ngIf="isObjectType(k, ObjectType.ViewChild)" class="decorator">
+        <span *ngIf="isComponentObjectType(k, ObjectType.ViewChild)" class="decorator">
           @ViewChild({{getSelector(k)}})
         </span>
-        <span *ngIf="isObjectType(k, ObjectType.ViewChildren)" class="decorator">
+        <span *ngIf="isComponentObjectType(k, ObjectType.ViewChildren)" class="decorator">
           @ViewChildren({{getSelector(k)}})
         </span>
-        <span *ngIf="isObjectType(k, ObjectType.ContentChild)" class="decorator">
+        <span *ngIf="isComponentObjectType(k, ObjectType.ContentChild)" class="decorator">
           @ContentChild({{getSelector(k)}})
         </span>
-        <span *ngIf="isObjectType(k, ObjectType.ContentChildren)" class="decorator">
+        <span *ngIf="isComponentObjectType(k, ObjectType.ContentChildren)" class="decorator">
           @ContentChildren({{getSelector(k)}})
         </span>
       </span>
@@ -61,6 +61,7 @@
        [id]="id"
        [level]="level + 1"
        [path]="path.concat([k])"
+       [componentMetadata]="componentMetadata"
        [metadata]="metadata"
        [state]="state[k]">
     </bt-render-state>

--- a/src/frontend/components/render-state/render-state.ts
+++ b/src/frontend/components/render-state/render-state.ts
@@ -17,6 +17,8 @@ import {
 
 import {getPropertyPath} from '../../../backend/utils';
 
+import {functionName} from '../../../utils';
+
 import {
   ComponentPropertyState,
   ExpandState,
@@ -88,13 +90,17 @@ export class RenderState {
       return `Array[${object.length}]`;
     }
     else if (object != null) {
-      if (Object.keys(object).length === 0) {
-        return '{}';
-      }
-      return 'Object';
-    }
+      const constructor = functionName(object.constructor) || typeof object;
 
-    if (object === null) {
+      if (/object/i.test(constructor)) {
+        if (Object.keys(object).length === 0) {
+          return '{}'; // special case to denote an empty object
+        }
+      }
+
+      return constructor;
+    }
+    else if (object === null) {
       return 'null';
     }
     else if (object === undefined) {

--- a/src/frontend/components/render-state/render-state.ts
+++ b/src/frontend/components/render-state/render-state.ts
@@ -23,6 +23,7 @@ import {
 } from '../../state';
 
 import {
+  ComponentMetadata,
   Metadata,
   Path,
   ObjectType,
@@ -43,6 +44,7 @@ export enum EmitState {
 })
 export class RenderState {
   @Input() id: string;
+  @Input() componentMetadata: ComponentMetadata;
   @Input() metadata: Metadata;
   @Input() level: number;
   @Input() path: Path;
@@ -122,12 +124,19 @@ export class RenderState {
     }
   }
 
-  private getMetadata(key: string): [ObjectType, any] {
-    return this.metadata.get(this.state[key]);
+  private getComponentMetadata(key: string): [ObjectType, any] {
+    const properties = this.componentMetadata.get(this.state);
+    if (properties) {
+      const matchingProperty = properties.find(p => p[0] === key);
+      if (matchingProperty) {
+        return [matchingProperty[1], matchingProperty[2]];
+      }
+    }
+    return null;
   }
 
   private isEmittable(key: string): boolean {
-    const metadata = this.getMetadata(key);
+    const metadata = this.metadata.get(this.state[key]);
     if (metadata) {
       return (metadata[0] & ObjectType.EventEmitter) !== 0
           || (metadata[0] & ObjectType.Subject) !== 0;
@@ -135,16 +144,15 @@ export class RenderState {
     return false;
   }
 
-  private isObjectType(key: string, type: ObjectType): boolean {
-    const metadata = this.getMetadata(key);
+  private isComponentObjectType(key: string, type: ObjectType): boolean {
+    const metadata = this.getComponentMetadata(key);
     if (metadata) {
       return (metadata[0] & type) !== 0;
     }
-    return false;
   }
 
   private getAlias(key: string): string {
-    const metadata = this.getMetadata(key);
+    const metadata = this.getComponentMetadata(key);
     if (metadata) {
       const additionalProperties = metadata[1];
       if (additionalProperties) {
@@ -154,7 +162,7 @@ export class RenderState {
   }
 
   private getSelector(key: string): string {
-    const metadata = this.getMetadata(key);
+    const metadata = this.getComponentMetadata(key);
     if (metadata) {
       const additionalProperties = metadata[1];
       if (additionalProperties) {

--- a/src/frontend/components/render-state/render-state.ts
+++ b/src/frontend/components/render-state/render-state.ts
@@ -1,5 +1,3 @@
-import md5 = require('md5');
-
 import {
   ChangeDetectionStrategy,
   Component,
@@ -125,7 +123,7 @@ export class RenderState {
   }
 
   private getMetadata(key: string): [ObjectType, any] {
-    return this.metadata.get(md5(serializePath(this.path.concat([key]))));
+    return this.metadata.get(this.state[key]);
   }
 
   private isEmittable(key: string): boolean {

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -263,7 +263,10 @@ class App {
           if (typeof beforeLoad === 'function') {
             beforeLoad();
           }
-          return response;
+
+          const {instance, metadata} = response;
+
+          return {instance, metadata: new Map(metadata)};
         });
 
       this.componentState.wait(node, promise);

--- a/src/frontend/frontend.ts
+++ b/src/frontend/frontend.ts
@@ -257,16 +257,19 @@ class App {
     const m = MessageFactory.selectComponent(node, node.isComponent);
 
     if (node.isComponent) {
-
       const promise = this.directConnection.handleImmediate(m)
         .then(response => {
           if (typeof beforeLoad === 'function') {
             beforeLoad();
           }
 
-          const {instance, metadata} = response;
+          const {instance, metadata, componentMetadata} = response;
 
-          return {instance, metadata: new Map(metadata)};
+          return {
+            instance,
+            metadata: new Map(metadata),
+            componentMetadata: new Map(componentMetadata),
+          };
         });
 
       this.componentState.wait(node, promise);

--- a/src/utils/scalar.ts
+++ b/src/utils/scalar.ts
@@ -1,6 +1,7 @@
 export const isScalar = value => {
   switch (typeof value) {
     case 'string':
+    case 'number':
     case 'boolean':
     case 'function':
     case 'undefined':

--- a/typings.json
+++ b/typings.json
@@ -17,7 +17,6 @@
     "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504",
     "filesystem": "registry:dt/filesystem#0.0.0+20160316155526",
     "filewriter": "registry:dt/filewriter#0.0.0+20160316155526",
-    "md5": "registry:dt/md5#2.1.0+20160521153251",
     "node": "registry:dt/node#6.0.0+20160823142437",
     "tape": "registry:dt/tape#4.2.2+20160317120654",
     "webrtc/mediastream": "registry:dt/webrtc/mediastream#0.0.0+20160317120654"


### PR DESCRIPTION
Now we retain the name of the type across backend->frontend serialization so that we can display the real object type in the "State" view. See:
![screen shot 2016-11-08 at 12 25 30 pm](https://cloud.githubusercontent.com/assets/1780164/20109567/a24397d2-a5ae-11e6-86e0-946d52f4dac3.png)

Resolves: https://github.com/rangle/augury/issues/775