### PR TITLE
Fix router tree

### DIFF
--- a/src/frontend/components/router-tree/router-tree.ts
+++ b/src/frontend/components/router-tree/router-tree.ts
@@ -3,6 +3,7 @@ import {
   Input,
   ViewChild,
   SimpleChanges,
+  ElementRef
 } from '@angular/core';
 
 import {Route} from '../../../backend/utils';
@@ -33,7 +34,7 @@ export class RouterTree {
 
   private treeConfig: TreeConfig;
 
-  constructor(private userActions: UserActions) {}
+  constructor(private userActions: UserActions, private element: ElementRef) {}
 
   private getTree(): TreeConfig {
     const tree = d3.layout.tree();
@@ -61,7 +62,7 @@ export class RouterTree {
 
     const tree = this.treeConfig.tree;
     const data = this.routerTree;
-    const gEl = document.getElementsByTagName('g')[0];
+    const gEl =  this.element.nativeElement.querySelector('g');
     let i = 0;
 
     // Compute the new tree layout.

--- a/src/styles/utils/colors.css
+++ b/src/styles/utils/colors.css
@@ -87,7 +87,7 @@ bt-injector-tree {
     background-color: #E5E5E5;
   }
 
-  & .select-element-active > svg  * > polygon {
+  & .select-element-active > svg * > polygon {
      fill: #5A5A5A;
   }
 
@@ -232,7 +232,7 @@ bt-injector-tree {
     background-color: #313131;
   }
 
-  & .select-element-active > svg  * > polygon {
+  & .select-element-active > svg * > polygon {
     fill: #ccc;
   }
 

--- a/src/styles/utils/colors.css
+++ b/src/styles/utils/colors.css
@@ -87,19 +87,19 @@ bt-injector-tree {
     background-color: #E5E5E5;
   }
 
-  & .select-element-active > svg > * > * > * > polygon {
+  & .select-element-active > svg  * > polygon {
      fill: #5A5A5A;
   }
 
-  & .select-element-active > svg > * > * > * > path {
+  & .select-element-active > svg * > path {
     stroke: #5A5A5A;
   }
 
-  & .select-element-active > svg > * > * > * > polygon {
+  & .select-element-active > svg * > polygon {
     fill: #4280EC;
   }
 
-  & .select-element-active > svg > * > * > * > path {
+  & .select-element-active > svg * > path {
     stroke: #4280EC;
   }
 
@@ -232,19 +232,24 @@ bt-injector-tree {
     background-color: #313131;
   }
 
-  & .select-element-active > svg > * > * > * > polygon {
+  & .select-element-active > svg  * > polygon {
     fill: #ccc;
   }
 
-  & .select-element-active > svg > * > * > * > path {
+  & .select-element-active > svg * > path {
     stroke: #ccc;
   }
 
-  & .select-element-active > svg > * > * > * > polygon {
+  & .select-element-active > svg * > polygon {
     fill: #4280EC;
   }
+<<<<<<< Updated upstream
   
   & .select-element-active > svg > * > * > * > path {
+=======
+
+  & .select-element-active > svg * > path {
+>>>>>>> Stashed changes
     stroke: #4280EC;
   }
 

--- a/src/styles/utils/colors.css
+++ b/src/styles/utils/colors.css
@@ -243,13 +243,9 @@ bt-injector-tree {
   & .select-element-active > svg * > polygon {
     fill: #4280EC;
   }
-<<<<<<< Updated upstream
-  
-  & .select-element-active > svg > * > * > * > path {
-=======
 
   & .select-element-active > svg * > path {
->>>>>>> Stashed changes
+
     stroke: #4280EC;
   }
 

--- a/src/styles/utils/colors.css
+++ b/src/styles/utils/colors.css
@@ -245,7 +245,6 @@ bt-injector-tree {
   }
 
   & .select-element-active > svg * > path {
-
     stroke: #4280EC;
   }
 


### PR DESCRIPTION
fixes router tree and retrieves the outer svg element now from the elementref instead of document.
We were using document.getElementByTagName and the 0'ist tag element on the document. However I added a new svg for select element, so it was referencing the incorrect svg. Now it queryselects from the elementreference of the component instead. Which I assume will not trigger a break anymore.

resolves #823

![](http://i.imgur.com/8Nib9OB.png)