### PR TITLE
Improve injector graph to show injected stuff only, with dep lines

### DIFF
--- a/example-apps/kitchen-sink-example/source/components/di-tree/component2.ts
+++ b/example-apps/kitchen-sink-example/source/components/di-tree/component2.ts
@@ -1,9 +1,11 @@
 import {Component, Inject} from '@angular/core';
 
 import Service2 from '../../services/service2';
+import Service4 from '../../services/service4';
 
 @Component({
   selector: 'component2',
+  providers: [ Service4],
   template: `
     <p>component2 init service2</p>
     {{service2Value}}

--- a/example-apps/kitchen-sink-example/source/components/di-tree/component5.ts
+++ b/example-apps/kitchen-sink-example/source/components/di-tree/component5.ts
@@ -5,7 +5,7 @@ import Service4 from '../../services/service4';
 
 @Component({
   selector: 'component5',
-  providers: [Service3, Service4],
+  providers: [Service3],
   template: `
     <p>component5 init: service3, service4</p>
     {{service3Value}}

--- a/src/frontend/components/injector-tree/injector-tree.ts
+++ b/src/frontend/components/injector-tree/injector-tree.ts
@@ -38,7 +38,6 @@ export class InjectorTree implements OnChanges {
   @Input() selectNode: EventEmitter<any>;
 
   private parentHierarchy;
-  private parentHierarchyDisplay;
   private svg: any;
 
   constructor(
@@ -56,35 +55,11 @@ export class InjectorTree implements OnChanges {
     }
   }
 
-  private addRootDependencies() {
-    const rootIndex = deserializePath(this.selectedNode.id).shift();
-
-    const rootElement = this.tree.roots[rootIndex];
-    if (rootElement == null) {
-      return;
-    }
-
-    this.selectedNode.dependencies.forEach(
-      (dependency: any) => {
-        if (this.selectedNode.injectors.indexOf(dependency.type) < 0) {
-          const parent = this.parseUtils.getDependencyLink
-            (this.tree, this.selectedNode.id, dependency.type);
-          if (!parent) {
-            rootElement.injectors.push(dependency.type);
-          }
-        }
-      });
-  }
-
   private displayTree() {
-    this.parentHierarchy = this.parseUtils.getParentHierarchy(this.tree, this.selectedNode,
-      node => {
-        return node.isComponent === true;
-      });
+    const mainHierarchy = this.parseUtils.getParentHierarchy(this.tree, this.selectedNode, node =>
+      node.isComponent === true);
 
-    this.parentHierarchyDisplay = this.parentHierarchy.concat([this.selectedNode]);
-
-    this.addRootDependencies();
+    this.parentHierarchy = [{ name: 'root', dependencies: [] }].concat(mainHierarchy).concat([this.selectedNode]);
 
     let firstChild: Element;
     while (firstChild = this.graphContainer.nativeElement.firstChild) {
@@ -99,24 +74,7 @@ export class InjectorTree implements OnChanges {
     this.render();
   }
 
-  private addPosition(positions: any, posX: number, posY: number, node: any, injector?: any) {
-    if (injector) {
-          positions[node.id].injectors[injector] = {
-            'x': posX,
-            'y': posY,
-            'injector': injector
-          };
-    } else {
-        positions[node.id] = {
-          'x': posX,
-          'y': posY,
-          'node': node,
-          'injectors': {}
-        };
-      }
-  }
-
-  private addNodeAndText(posX: number, posY: number, title: any, positions: any, clazz: string) {
+  private addNodeAndText(posX: number, posY: number, title: any, clazz: string) {
       this.graphUtils.addCircle(this.svg, posX, posY, NODE_RADIUS, clazz);
       this.graphUtils.addText(this.svg, posX - 6, posY - 15, title);
   }
@@ -127,100 +85,54 @@ export class InjectorTree implements OnChanges {
     }
 
     let posX, posY, x1, y1, x2, y2;
-    const positions = {};
 
-    let i: number = 0;
-    this.parentHierarchy.forEach((node) => {
+    this.parentHierarchy.forEach((node, hierarchyIdx: number) => {
       const nodeX = START_X;
-      const nodeY = START_Y + NODE_INCREMENT_Y * i;
+      const nodeY = START_Y + NODE_INCREMENT_Y * hierarchyIdx;
 
-      this.addPosition(positions, nodeX, nodeY, node);
+      node.dependencies.forEach((dependency, j: number) => {
+        const injectorX = nodeX + NODE_INCREMENT_X + NODE_INCREMENT_X * j;
 
-      let j: number = 0;
-      node.injectors.forEach((injector) => {
-        if (injector !== node.name) {
-          const injectorX = nodeX + NODE_INCREMENT_X + NODE_INCREMENT_X * j;
+        x1 = injectorX - NODE_INCREMENT_X + NODE_RADIUS;
+        y1 = nodeY;
+        x2 = injectorX - NODE_RADIUS;
+        y2 = nodeY;
+        this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'stroke-service');
 
-          x1 = injectorX - NODE_INCREMENT_X + NODE_RADIUS;
-          y1 = nodeY;
-          x2 = injectorX - NODE_RADIUS;
-          y2 = nodeY;
-          this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'stroke-service');
+        this.addNodeAndText(injectorX, nodeY, dependency.type, 'fill-service stroke-service');
 
-          this.addNodeAndText(injectorX, nodeY, injector, positions, 'fill-service stroke-service');
-          this.addPosition(positions, injectorX, nodeY, node, injector);
-
-          j++;
-        }
       });
 
-      if (i > 0) {
+      if (hierarchyIdx > 0) {
         x1 = nodeX;
-        y1 = START_Y + NODE_INCREMENT_Y * (i - 1) + NODE_RADIUS;
+        y1 = START_Y + NODE_INCREMENT_Y * (hierarchyIdx - 1) + NODE_RADIUS;
         x2 = nodeX;
         y2 = nodeY - (20 + NODE_RADIUS);
         this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'arrow stroke-component');
       }
-      this.addNodeAndText(nodeX, nodeY, node.name, positions, 'fill-component stroke-component');
 
-      i++;
-    });
-
-    let j: number = 0;
-    this.selectedNode.injectors.forEach((injector) => {
-      if (injector !== this.selectedNode.name) {
-        posX = START_X + NODE_INCREMENT_X + NODE_INCREMENT_X * j;
-        posY = START_Y + NODE_INCREMENT_Y * i;
-
-        x1 = posX - NODE_INCREMENT_X + NODE_RADIUS;
-        y1 = posY;
-        x2 = posX - NODE_RADIUS;
-        y2 = posY;
-        this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'stroke-service');
-
-        this.graphUtils.addCircle(this.svg, posX, posY, NODE_RADIUS, 'fill-service stroke-service');
-        this.graphUtils.addText(this.svg, posX - 6, posY - 15, injector);
-
-        j++;
-      }
-    });
-
-    posX = START_X;
-    posY = START_Y + NODE_INCREMENT_Y * i;
-    this.addNodeAndText(posX, posY, this.selectedNode.name, positions, 'fill-root stroke-root');
-    this.addPosition(positions, posX, posY, this.selectedNode);
-
-    if (i > 0) {
-      x1 = START_X;
-      y1 = START_Y + NODE_INCREMENT_Y * (i - 1) + NODE_RADIUS;
-      x2 = START_X;
-      y2 = posY - 28;
-      this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'arrow stroke-component');
-    }
-
-    this.selectedNode.dependencies.forEach((dependency: any) => {
-      const providedForSelf = this.selectedNode.providers.reduce((prev, curr, idx, p) =>
-        prev ? prev : p[idx].key === dependency.type && dependency.decorators.indexOf('@SkipSelf') < 0, false);
-      if (providedForSelf) {
-        return;
-      }
-
-      const parent = this.parseUtils.getDependencyLink
-        (this.tree, this.selectedNode.id, dependency.type);
-      if (parent) {
-        const service = positions[parent.id].injectors[dependency.type];
-        if (service) {
-          x1 = positions[this.selectedNode.id].x + 5;
-          y1 = positions[this.selectedNode.id].y - 10;
-          // Convert vector between the two nodes to desirable polar coordinates
-          const rho = Math.sqrt(((service.x - x1) ** 2) + ((y1 - service.y) ** 2)) - (NODE_RADIUS * 1.5);
-          const theta = Math.atan2(service.y - y1, service.x - x1);
-          // Convert back to euclidean coordinates
-          x2 = x1 + rho * Math.cos(theta);
-          y2 = y1 + rho * Math.sin(theta);
-          this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'stroke-root arrow dashed5');
+      // draw dependency links (if injectable was provided higher than current node)
+      node.dependencies.forEach((dependency: any, depIndex: number) => {
+        const providedForSelf = node.providers.reduce((prev, curr, idx, p) =>
+          prev ? prev : p[idx].key === dependency.type && dependency.decorators.indexOf('@SkipSelf') < 0, false);
+        if (providedForSelf) {
+          return;
         }
-      }
+
+        const parent = this.parseUtils.getDependencyLink(this.tree, node.id, dependency.type);
+
+        // no parent means 'root'. TODO:(steven.kampen) Improve with NgModule context
+        const parentIdx = !parent ? 0 : this.parentHierarchy.reduce((prev, curr, idx, p) =>
+          prev >= 0 ? prev : p[idx].name === parent.name ? idx : prev, -1);
+
+        x1 = START_X + NODE_INCREMENT_X * (depIndex + 1);
+        y1 = START_Y + hierarchyIdx * NODE_INCREMENT_Y;
+        x2 = START_X;
+        y2 = START_Y + NODE_INCREMENT_Y * parentIdx;
+
+        this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'stroke-dependency dashed5');
+      });
+      this.addNodeAndText(nodeX, nodeY, node.name, 'fill-component stroke-component');
     });
 
     this.svg.append('defs').selectAll('marker')

--- a/src/frontend/components/injector-tree/injector-tree.ts
+++ b/src/frontend/components/injector-tree/injector-tree.ts
@@ -24,6 +24,7 @@ const START_Y: number = 70;
 const NODE_INCREMENT_X: number = 100;
 const NODE_INCREMENT_Y: number = 60;
 const NODE_RADIUS: number = 8;
+const MAX_LABEL_CHARS = 14;
 
 @Component({
   selector: 'bt-injector-tree',
@@ -74,9 +75,9 @@ export class InjectorTree implements OnChanges {
     this.render();
   }
 
-  private addNodeAndText(posX: number, posY: number, title: any, clazz: string) {
+  private addNodeAndText(posX: number, posY: number, title: any, clazz: string, maxChars: number = 0) {
       this.graphUtils.addCircle(this.svg, posX, posY, NODE_RADIUS, clazz);
-      this.graphUtils.addText(this.svg, posX - 6, posY - 15, title);
+      this.graphUtils.addText(this.svg, posX - 6, posY - 15, title, maxChars);
   }
 
   private render() {
@@ -87,8 +88,6 @@ export class InjectorTree implements OnChanges {
     // render legend
     this.graphUtils.addText(this.svg, 5, 15, 'Dependency Origin');
     this.graphUtils.addLine(this.svg, 33, 30, 83, 30, 'stroke-dependency origin dashed5');
-
-    // this.addNodeAndText(80, 25, 'Self-Provided', 'fill-component stroke-component');
     this.graphUtils.addText(this.svg, 150, 15, 'Self Provided');
     this.graphUtils.addCircle(this.svg, 195, 30, NODE_RADIUS, 'fill-dependency stroke-dependency provided-here');
 
@@ -110,8 +109,10 @@ export class InjectorTree implements OnChanges {
 
         const selfProvides = parent === node;
 
+        // draw injected dependency name and node circle
         this.addNodeAndText(injectorX, nodeY, dependency.type,
-          `fill-dependency stroke-dependency ${selfProvides ? 'provided-here' : ''}`);
+          `fill-dependency stroke-dependency ${selfProvides ? 'provided-here' : ''}`,
+          depIndex === node.dependencies.length - 1 ? 0 : MAX_LABEL_CHARS);
 
         // draw dependency links (if injectable was provided higher than current node)
         if (selfProvides) {
@@ -128,6 +129,7 @@ export class InjectorTree implements OnChanges {
         x2 = START_X;
         y2 = START_Y + NODE_INCREMENT_Y * parentIdx;
 
+        // draw dependency origin line
         this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'stroke-dependency origin dashed5');
 
       });
@@ -137,10 +139,13 @@ export class InjectorTree implements OnChanges {
         y1 = START_Y + NODE_INCREMENT_Y * (hierarchyIdx - 1) + NODE_RADIUS;
         x2 = nodeX;
         y2 = nodeY - (20 + NODE_RADIUS);
+        // draw parent to child component line
         this.graphUtils.addLine(this.svg, x1, y1, x2, y2, 'arrow stroke-component');
       }
 
-      this.addNodeAndText(nodeX, nodeY, node.name, 'fill-component stroke-component');
+      // draw component name and node circle
+      this.addNodeAndText(nodeX, nodeY, node.name, 'fill-component stroke-component',
+        hierarchyIdx === 0 || !node.dependencies.length ? 0 : MAX_LABEL_CHARS);
     });
 
     this.svg.append('defs').selectAll('marker')

--- a/src/frontend/components/injector-tree/injector-tree.ts
+++ b/src/frontend/components/injector-tree/injector-tree.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../tree';
 
 const START_X: number = 20;
-const START_Y: number = 30;
+const START_Y: number = 70;
 const NODE_INCREMENT_X: number = 100;
 const NODE_INCREMENT_Y: number = 60;
 const NODE_RADIUS: number = 8;
@@ -83,6 +83,14 @@ export class InjectorTree implements OnChanges {
     if (this.tree == null) {
       return;
     }
+
+    // render legend
+    this.graphUtils.addText(this.svg, 5, 15, 'Dependency Origin');
+    this.graphUtils.addLine(this.svg, 30, 33, 83, 30, 'stroke-dependency origin dashed5');
+
+    // this.addNodeAndText(80, 25, 'Self-Provided', 'fill-component stroke-component');
+    this.graphUtils.addText(this.svg, 150, 15, 'Self Provided');
+    this.graphUtils.addCircle(this.svg, 195, 30, NODE_RADIUS, 'fill-dependency stroke-dependency provided-here');
 
     let posX, posY, x1, y1, x2, y2;
 

--- a/src/frontend/components/injector-tree/injector-tree.ts
+++ b/src/frontend/components/injector-tree/injector-tree.ts
@@ -86,7 +86,7 @@ export class InjectorTree implements OnChanges {
 
     // render legend
     this.graphUtils.addText(this.svg, 5, 15, 'Dependency Origin');
-    this.graphUtils.addLine(this.svg, 30, 33, 83, 30, 'stroke-dependency origin dashed5');
+    this.graphUtils.addLine(this.svg, 33, 30, 83, 30, 'stroke-dependency origin dashed5');
 
     // this.addNodeAndText(80, 25, 'Self-Provided', 'fill-component stroke-component');
     this.graphUtils.addText(this.svg, 150, 15, 'Self Provided');

--- a/src/frontend/utils/graph-utils.ts
+++ b/src/frontend/utils/graph-utils.ts
@@ -1,10 +1,11 @@
 export class GraphUtils {
-  addText(svg: any, x: number, y: number, text: string) {
+  addText(svg: any, x: number, y: number, text: string, maxChars = 0) {
+    const fittedText = maxChars > 0 && text.length > maxChars ? `${text.slice(0, maxChars - 3)}...` : text;
     svg
       .append('text')
       .attr('x', x)
       .attr('y', y)
-      .text(text);
+      .text(fittedText);
   }
 
   addCircle(svg: any, x: number, y: number, r: number, clazz: string) {

--- a/src/frontend/utils/parse-utils.test.ts
+++ b/src/frontend/utils/parse-utils.test.ts
@@ -116,6 +116,12 @@ test('utils/parse-utils: getParentNodeIds', t => {
 
 test('utils/parse-utils: getDependencyLink', t => {
   t.plan(1);
+  const node = {
+    id: '0 2 2',
+    name: 'four',
+    injectors: ['service1'],
+    providers: []
+  };
   const mockData = [{
     id: '0',
     name: 'mockData',
@@ -131,22 +137,18 @@ test('utils/parse-utils: getDependencyLink', t => {
       children: [{
         id: '0 2 1',
         name: 'three'
-      }, {
-        id: '0 2 2',
-        name: 'four',
-        injectors: ['service1']
-      }]
+      }, node]
     }]
   }];
 
   const nodeId = '0 2 2';
-  const dependency = 'service1';
+  const dependency = { type: 'service1', decorators: [] };
 
   const parseUtils: ParseUtils = new ParseUtils();
 
   const tree = createTree(<any> mockData);
 
-  const output = parseUtils.getDependencyLink(tree, nodeId, dependency);
+  const output = parseUtils.getDependencyProvider(tree, (<any>node), dependency);
 
   t.deepEqual(mockData[0], output, 'result should be equal to output');
   t.end();

--- a/src/frontend/utils/parse-utils.test.ts
+++ b/src/frontend/utils/parse-utils.test.ts
@@ -114,42 +114,49 @@ test('utils/parse-utils: getParentNodeIds', t => {
   t.end();
 });
 
-test('utils/parse-utils: getDependencyLink', t => {
+test('utils/parse-utils: getDependencyProvider', t => {
   t.plan(1);
   const node = {
-    id: '0 2 2',
+    id: '0 1 1',
     name: 'four',
     injectors: ['service1'],
-    providers: []
+    providers: [],
   };
   const mockData = [{
     id: '0',
     name: 'mockData',
     injectors: ['service1'],
-    children: [{
-      id: '0 1',
-      name: 'one',
-      injectors: ['service2']
-    }, {
-      id: '0 2',
-      name: 'two',
-      injectors: ['service3'],
-      children: [{
-        id: '0 2 1',
-        name: 'three'
-      }, node]
-    }]
+    providers: [{ key: 'service1' }],
+    children: [
+      {
+        id: '0 0',
+        name: 'one',
+        injectors: ['service2'],
+        providers: [],
+      },
+      {
+        id: '0 1',
+        name: 'two',
+        injectors: ['service3'],
+        providers: [],
+        children: [
+          {
+            id: '0 1 0',
+            name: 'three'
+          },
+          node,
+        ],
+      },
+    ]
   }];
 
-  const nodeId = '0 2 2';
   const dependency = { type: 'service1', decorators: [] };
 
   const parseUtils: ParseUtils = new ParseUtils();
 
   const tree = createTree(<any> mockData);
 
-  const output = parseUtils.getDependencyProvider(tree, (<any>node), dependency);
-
+  const output = parseUtils.getDependencyProvider(tree, node.id, dependency);
   t.deepEqual(mockData[0], output, 'result should be equal to output');
   t.end();
 });

--- a/src/styles/properties.css
+++ b/src/styles/properties.css
@@ -11,11 +11,13 @@
    */
   --lmode-igraph-component-primary: #2828AB;
   --lmode-igraph-component-secondary: #EBF2FC;
+  --lmode-igraph-dep-link: #C6E3FF;
   --lmode-igraph-service-primary: #F05057;
   --lmode-igraph-service-secondary: #FFF0F0;
 
   --dmode-igraph-component-primary: #23a9ab;
   --dmode-igraph-component-secondary: #EBF2FC;
+  --dmode-igraph-dep-link: #C6E3FF;
   --dmode-igraph-service-primary: #F05057;
   --dmode-igraph-service-secondary: #FFF0F0;
 

--- a/src/styles/properties.css
+++ b/src/styles/properties.css
@@ -11,15 +11,15 @@
    */
   --lmode-igraph-component-primary: #2828AB;
   --lmode-igraph-component-secondary: #EBF2FC;
-  --lmode-igraph-dep-link: #C6E3FF;
-  --lmode-igraph-service-primary: #F05057;
-  --lmode-igraph-service-secondary: #FFF0F0;
+  --lmode-igraph-dependency-primary: #F05057;
+  --lmode-igraph-dependency-secondary: #FFF0F0;
+  --lmode-igraph-dependency-legend-origin: #C6E3FF;
+  --lmode-igraph-dependency-legend-provided: #ffa4a4;
 
   --dmode-igraph-component-primary: #23a9ab;
   --dmode-igraph-component-secondary: #EBF2FC;
-  --dmode-igraph-dep-link: #C6E3FF;
-  --dmode-igraph-service-primary: #F05057;
-  --dmode-igraph-service-secondary: #FFF0F0;
+  --dmode-igraph-dependency-primary: #F05057;
+  --dmode-igraph-dependency-secondary: #FFF0F0;
 
 
   /**

--- a/src/styles/utils/colors.css
+++ b/src/styles/utils/colors.css
@@ -24,14 +24,13 @@ bt-injector-tree {
       stroke: var(--lmode-igraph-component-primary);
     }
 
-    &service {
-      stroke: var(--lmode-igraph-service-primary);
-    }
     &dependency {
-      stroke: var(--lmode-igraph-dep-link);
+      stroke: var(--lmode-igraph-dependency-primary);
     }
   }
-
+  & .stroke-dependency.origin {
+    stroke: var(--lmode-igraph-dependency-legend-origin);
+  }
   & .fill- {
     &root {
       fill: var(--lmode-igraph-component-primary);
@@ -41,9 +40,12 @@ bt-injector-tree {
       fill: #EBF2FC;
     }
 
-    &service {
+    &dependency {
       fill: #FFF0F0;
     }
+  }
+  & .fill-dependency.provided-here {
+    fill: var(--lmode-igraph-dependency-legend-provided);
   }
 }
 

--- a/src/styles/utils/colors.css
+++ b/src/styles/utils/colors.css
@@ -27,6 +27,9 @@ bt-injector-tree {
     &service {
       stroke: var(--lmode-igraph-service-primary);
     }
+    &dependency {
+      stroke: var(--lmode-igraph-dep-link);
+    }
   }
 
   & .fill- {


### PR DESCRIPTION
resolves #624 

Changes the injector graph so that each component shows (on it's row) just the things that are injected, with dashed lines showing the origin of that injectable in the hierarchy (where it was provided).

<img width="345" alt="screen shot 2016-12-07 at 5 40 29 pm" src="https://cloud.githubusercontent.com/assets/898763/20976900/45f57362-bca4-11e6-93cd-9e0c86a2728b.png">
