### PR TITLE
Don’t allow spaces in function names

### DIFF
--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -125,7 +125,7 @@ function map(operation: Operation, value) {
           /// long as they do not reference closures that are not accessible
           /// in the context they are running in.
           if (typeof value === 'function') {
-            return `function ${functionName(value)}() {}`;
+            return `function ${functionName(value).split(' ').join('_')}() {}`;
           }
 
           let index = operation.visits.get(value);


### PR DESCRIPTION
resolves #699 
resolves #903 

@clbond `functionName` utility produces `bound theFunctionName` for bound functions which broke deserialization. Can you please review this fix?