### PR TITLE
Fix nested & named outlet route paths

### DIFF
--- a/src/backend/utils/parse-router.ts
+++ b/src/backend/utils/parse-router.ts
@@ -29,7 +29,7 @@ export function parseRoutes(router: any): MainRoute {
   return root;
 }
 
-function assignChildrenToParent(parent, children): [any] {
+function assignChildrenToParent(parentPath, children): [any] {
   return children.map((child) => {
     const childName = childRouteName(child);
     const childDescendents: [any] = child._loadedConfig ? child._loadedConfig.routes : child.children;
@@ -37,15 +37,21 @@ function assignChildrenToParent(parent, children): [any] {
     // only found in aux routes, otherwise property will be undefined
     const isAuxRoute = !!child.outlet;
 
-    return {
+    const pathFragment = child.outlet ? `(${child.outlet}:${child.path})` : child.path;
+
+    const routeConfig = {
       handler: childName,
       name: childName,
-      parent: parent,
-      path: `/${child.path}`,
+      path: `${parentPath ? parentPath : ''}/${pathFragment}`.split('//').join('/'),
       isAux: isAuxRoute,
-      children: childDescendents ?
-        assignChildrenToParent(this, childDescendents) : []
+      children: [],
     };
+
+    if (childDescendents) {
+      routeConfig.children = assignChildrenToParent(routeConfig.path, childDescendents);
+    }
+
+    return routeConfig;
   });
 }
 

--- a/src/backend/utils/parse-router.ts
+++ b/src/backend/utils/parse-router.ts
@@ -39,8 +39,11 @@ function assignChildrenToParent(parentPath, children): [any] {
 
     const pathFragment = child.outlet ? `(${child.outlet}:${child.path})` : child.path;
 
-    const routeConfig = {
+    const routeConfig: Route = {
       handler: childName,
+      data: [],
+      hash: null,
+      specificity: null,
       name: childName,
       path: `${parentPath ? parentPath : ''}/${pathFragment}`.split('//').join('/'),
       isAux: isAuxRoute,
@@ -49,6 +52,17 @@ function assignChildrenToParent(parentPath, children): [any] {
 
     if (childDescendents) {
       routeConfig.children = assignChildrenToParent(routeConfig.path, childDescendents);
+    }
+
+    if (child.data) {
+      for (const el in child.data) {
+        if (child.data.hasOwnProperty(el)) {
+          routeConfig.data.push({
+            key: el,
+            value: child.data[el],
+          });
+        }
+      }
     }
 
     return routeConfig;

--- a/src/frontend/components/router-info/router-info.html
+++ b/src/frontend/components/router-info/router-info.html
@@ -39,12 +39,14 @@
         </span>
         <ul class="list-reset">
           <li *ngFor="let el of selectedRoute.data">
-            <span class="info-key">
-              {{el.key}}:
+            <div class="pl4">
+              <span class="info-key">
+                {{el.key}}:
               </span>
-            <span class="info-value">
-              {{el.value}}
+              <span class="info-value">
+                {{el.value}}
               </span>
+            </div>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
resolves #917 
resolves #914

@rajinder-yadav While addressing this I noticed that we were also not computing the path properly for named outlet routes. What was previously `/parks/park3` should be `/parks/(parkit:park3)`, where `parkit` is the outlet name. This PR fixes that too.

Edit: I've added the fix for #914 here also.