### PR TITLE
Validate origin in message listener

### DIFF
--- a/src/communication/message-dispatch.ts
+++ b/src/communication/message-dispatch.ts
@@ -113,6 +113,8 @@ export const browserDispatch = <T>(message: Message<T>) => {
 
 window.addEventListener('message',
   (event: MessageEvent) => {
-    browserDispatch(event.data);
+    if (event.source === window) {
+      browserDispatch(event.data);
+    }
   });
 


### PR DESCRIPTION
Hi!

Augury does not validate message origin in event listener which allows attackers to post arbitrary messages to target pages. What is even worse is that data serialization in messages used by the extension is basically evaluation of JavaScript, which makes it possible to gain XSS on any website provided that a user installed the extension.

PoC:

```javascript
targetWindow.postMessage({
	messageSource: 'AUGURY_INSPECTED_APPLICATION', 
	messageType: 1, 
	serialize: 2, 
	content: 'alert(1)'
}, '*')
```