### PR TITLE
Remove unnecessary permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,6 @@
   "version": "1.6.0",
   "description": "Extends the Developer Tools, adding tools for debugging and profiling Angular 2.0 applications.",
   "permissions": [
-    "tabs",
-    "<all_urls>",
     "storage"
   ],
   "browser_action": {


### PR DESCRIPTION
@sumitarora @clbond We looked into our usage of the `<all_urls>` permission and it seems that it's not necessary? Everything works as expected. If either of you can shed any light on that before it's merged, that would be appreciated.

resolves #1068 