### PR TITLE
Capture, detail and report backend + frontend errors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
   "devtools_page": "index.html",
   "background": {
     "scripts": [
-      "build/channel.js"
+      "build/background.js"
     ],
     "persistent": false
   },

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "postcss-cssnext": "^2.5.2",
     "postcss-import": "^9.1.0",
     "postcss-loader": "^1.0.0",
+    "raven-js": "^3.14.2",
     "raw-loader": "^0.5.1",
     "reflect-metadata": "0.1.9",
     "rimraf": "2.5.4",

--- a/src/communication/application-error.ts
+++ b/src/communication/application-error.ts
@@ -16,8 +16,12 @@ export enum ApplicationErrorType {
 }
 
 export interface ApplicationError {
+
   /// The class of error being represented
-  error: ApplicationErrorType;
+  errorType: ApplicationErrorType;
+
+  /// The class of error being represented
+  error?: Error;
 
   /// Additional details about the error
   details: string;
@@ -27,9 +31,10 @@ export interface ApplicationError {
 }
 
 export class ApplicationError implements ApplicationError {
-  constructor(error: ApplicationErrorType, details?: string, stack?: string) {
+  constructor(errorType: ApplicationErrorType, error?: Error, details?: string, stack?: string) {
+    this.errorType = errorType;
     this.error = error;
-    this.details = details;
-    this.stackTrace = stack || new Error().stack;
+    this.details = details || error ? error.message : null;
+    this.stackTrace = stack || error ? error.stack : new Error().stack;
   }
 }

--- a/src/communication/message-factory.ts
+++ b/src/communication/message-factory.ts
@@ -11,7 +11,10 @@ import {
 
 import {MessageType} from './message-type';
 
-import {ApplicationError} from './application-error';
+import {
+  ApplicationError,
+  ApplicationErrorType,
+} from './application-error';
 
 import {getRandomHash} from './hash';
 
@@ -175,6 +178,22 @@ export abstract class MessageFactory {
     return create({
       messageType: MessageType.ApplicationError,
       content: error,
+    });
+  }
+
+  static uncaughtApplicationError(error: Error): Message<ApplicationError> {
+    return create({
+      messageType: MessageType.ApplicationError,
+      content: serialize(new ApplicationError(ApplicationErrorType.UncaughtException, error)),
+      serialize: Serialize.Recreator,
+    });
+  }
+
+  static sendUncaughtError(error: Error): Message<Error> {
+    return create({
+      messageType: MessageType.SendUncaughtError,
+      content: serialize(error),
+      serialize: Serialize.Recreator,
     });
   }
 

--- a/src/communication/message-type.ts
+++ b/src/communication/message-type.ts
@@ -16,6 +16,9 @@ export enum MessageType {
   /// An error has occurred in the backend and is being transmitted to the frontend
   ApplicationError,
 
+  /// User signals "report this error".
+  SendUncaughtError,
+
   /// Post a message to the browser event queue so that it can be unwrapped and
   /// posted to the extension from the content-script. There is no pipe that is
   /// direct from the backend to the frontend, so this allows us to bounce the

--- a/src/frontend/app.css
+++ b/src/frontend/app.css
@@ -1,3 +1,0 @@
-pre {
-  margin: 25px;
-}

--- a/src/frontend/app.html
+++ b/src/frontend/app.html
@@ -1,9 +1,11 @@
 <div *ngIf="hasContent"
   class="clearfix vh-100 overflow-hidden flex flex-column"
   [ngClass]="options.theme === Theme.Dark ? 'dark' : 'light'">
-  <template [ngIf]="error">
-    <render-error [error]="error"></render-error>
-  </template>
+  <div *ngIf="error">
+    <render-error
+      (reportError)="onReportError()"
+      [error]="error"></render-error>
+  </div>
   <bt-app-trees #trees *ngIf="error === null"
     class="flex flex-column flex-auto"
     [componentState]="componentState"

--- a/src/frontend/app.html
+++ b/src/frontend/app.html
@@ -1,7 +1,7 @@
 <div *ngIf="hasContent"
   class="clearfix vh-100 overflow-hidden flex flex-column"
   [ngClass]="options.theme === Theme.Dark ? 'dark' : 'light'">
-  <div *ngIf="error">
+  <div class="vh-100" *ngIf="error">
     <render-error
       (reportError)="onReportError()"
       [error]="error"></render-error>

--- a/src/frontend/components/render-error/render-error.html
+++ b/src/frontend/components/render-error/render-error.html
@@ -1,5 +1,5 @@
 <div class="p3 m3" *ngIf="error">
-  <div [ngSwitch]="error.error" style="font-size: 1.25em">
+  <div [ngSwitch]="error.errorType" style="font-size: 1.25em">
     <div *ngSwitchCase="ApplicationErrorType.DebugInformationMissing">
       <p>
         Debug information is missing from this build.
@@ -13,6 +13,9 @@
         Try disabling AoT (if you are using the <span class="monospace">ng</span> command-line tool, try
         running <span class="monospace">ng</span> with the <span class="monospace">--aot=false</span> flag)
       </p>
+    </div>
+    <div class="flex flex-column" *ngSwitchCase="ApplicationErrorType.UncaughtException">
+      <report-error [error]="error" (reportError)="reportError.emit(true)"></report-error>
     </div>
     <div *ngSwitchCase="ApplicationErrorType.NotNgApp">
       <p class="h1 message-gray">
@@ -31,17 +34,6 @@
         If this is an Angular application, please rebuild your application in debug mode or remove the
         call to <span class="monospace">enableProdMode()</span>.
       </p>
-    </div>
-    <div *ngSwitchCase="ApplicationErrorType.UncaughtException">
-      <p>
-        An uncaught exception prevents Augury from continuing. A stack trace is reproduced below.
-      </p>
-      <p class="pt3" *ngIf="error.details">
-        {{error.details}}
-      </p>
-      <pre class="pt3">
-        {{error.stackTrace}}
-      </pre>
     </div>
   </div>
 </div>

--- a/src/frontend/components/render-error/render-error.html
+++ b/src/frontend/components/render-error/render-error.html
@@ -1,39 +1,48 @@
-<div class="p3 m3" *ngIf="error">
+<div class="vh-100" *ngIf="error">
   <div [ngSwitch]="error.errorType" style="font-size: 1.25em">
     <div *ngSwitchCase="ApplicationErrorType.DebugInformationMissing">
-      <p>
-        Debug information is missing from this build.
-      </p>
-      <p class="pt3">
-        One possible cause may be if your application was built with AoT (ahead-of-time compilation).
-        Augury cannot debug builds that use AoT because Angular does not provide the same debugging
-        information that it does for non-AoT builds.
-      </p>
-      <p class="pt3">
-        Try disabling AoT (if you are using the <span class="monospace">ng</span> command-line tool, try
-        running <span class="monospace">ng</span> with the <span class="monospace">--aot=false</span> flag)
-      </p>
+      <div class="p3 m3">
+        <p>
+          Debug information is missing from this build.
+        </p>
+        <p class="pt3">
+          One possible cause may be if your application was built with AoT (ahead-of-time compilation).
+          Augury cannot debug builds that use AoT because Angular does not provide the same debugging
+          information that it does for non-AoT builds.
+        </p>
+        <p class="pt3">
+          Try disabling AoT (if you are using the <span class="monospace">ng</span> command-line tool, try
+          running <span class="monospace">ng</span> with the <span class="monospace">--aot=false</span> flag)
+        </p>
+      </div>
     </div>
-    <div class="flex flex-column" *ngSwitchCase="ApplicationErrorType.UncaughtException">
-      <report-error [error]="error" (reportError)="reportError.emit(true)"></report-error>
+    <div class="vh-100" *ngSwitchCase="ApplicationErrorType.UncaughtException">
+      <report-error
+        [error]="error"
+        (reportError)="reportError.emit(true)">
+      </report-error>
     </div>
     <div *ngSwitchCase="ApplicationErrorType.NotNgApp">
-      <p class="h1 message-gray">
-        This application is not an Angular application.
-      </p>
-      <p class="h3 message-gray">
-        This application cannot be inspected using Augury.
-      </p>
+      <div class="p3 m3">
+        <p class="h1 message-gray">
+          This application is not an Angular application.
+        </p>
+        <p class="h3 message-gray">
+          This application cannot be inspected using Augury.
+        </p>
+      </div>
     </div>
     <div *ngSwitchCase="ApplicationErrorType.ProductionMode">
-      <p>
-        This application is running in production mode
-        and therefore cannot be inspected using Augury.
-      </p>
-      <p class="pt3">
-        If this is an Angular application, please rebuild your application in debug mode or remove the
-        call to <span class="monospace">enableProdMode()</span>.
-      </p>
+      <div class="p3 m3">
+        <p>
+          This application is running in production mode
+          and therefore cannot be inspected using Augury.
+        </p>
+        <p class="pt3">
+          If this is an Angular application, please rebuild your application in debug mode or remove the
+          call to <span class="monospace">enableProdMode()</span>.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/frontend/components/report-error/report-error.css
+++ b/src/frontend/components/report-error/report-error.css
@@ -1,3 +1,8 @@
+.report-error-heading {
+  background: #F4CE42;
+}
+
 .stack-trace {
   overflow: auto;
+  color: #FF2525;
 }

--- a/src/frontend/components/report-error/report-error.css
+++ b/src/frontend/components/report-error/report-error.css
@@ -1,0 +1,3 @@
+.stack-trace {
+  overflow: auto;
+}

--- a/src/frontend/components/report-error/report-error.html
+++ b/src/frontend/components/report-error/report-error.html
@@ -1,13 +1,17 @@
-<div class="flex flex-column flex-grow" *ngIf="error">
-  <div class="stack-trace flex flex-none">
-    <p>
-      An uncaught exception prevents Augury from continuing. A stack trace is reproduced below.
-      <button (click)="reportError.emit(true)">Send Report</button>
-    </p>
+<div class="vh-100 flex flex-column" *ngIf="error">
+  <div class="report-error-heading">
+    <div class="p3">
+      <p>
+        An uncaught exception prevents Augury from continuing. A stack trace is reproduced below.
+        <button (click)="reportError.emit(true)">Send Report</button>
+      </p>
+    </div>
   </div>
-  <div class="stack-trace flex flex-grow">
-    <pre>
-      {{error.error.stack}}
-    </pre>
+  <div class="stack-trace">
+    <div class="p3 m3">
+      <pre>
+        {{error.error.stack}}
+      </pre>
+    </div>
   </div>
 </div>

--- a/src/frontend/components/report-error/report-error.html
+++ b/src/frontend/components/report-error/report-error.html
@@ -1,0 +1,13 @@
+<div class="flex flex-column flex-grow" *ngIf="error">
+  <div class="stack-trace flex flex-none">
+    <p>
+      An uncaught exception prevents Augury from continuing. A stack trace is reproduced below.
+      <button (click)="reportError.emit(true)">Send Report</button>
+    </p>
+  </div>
+  <div class="stack-trace flex flex-grow">
+    <pre>
+      {{error.error.stack}}
+    </pre>
+  </div>
+</div>

--- a/src/frontend/components/report-error/report-error.ts
+++ b/src/frontend/components/report-error/report-error.ts
@@ -11,12 +11,11 @@ import {
 } from '../../../communication';
 
 @Component({
-  selector: 'render-error',
-  template: require('./render-error.html'),
+  selector: 'report-error',
+  template: require('./report-error.html'),
+  styles: [require('to-string!./report-error.css')],
 })
-export class RenderError {
+export class ReportError {
   @Input() private error: ApplicationError;
   @Output() private reportError: EventEmitter<boolean> = new EventEmitter<boolean>();
-
-  private ApplicationErrorType = ApplicationErrorType;
 }

--- a/src/frontend/module.ts
+++ b/src/frontend/module.ts
@@ -1,4 +1,4 @@
-import {NgModule, enableProdMode} from '@angular/core';
+import {NgModule, ErrorHandler, enableProdMode} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
@@ -24,10 +24,13 @@ import {StateValues} from './components/state-values/state-values';
 import {TabMenu} from './components/tab-menu/tab-menu';
 import {TreeView} from './components/tree-view/tree-view';
 import {RenderError} from './components/render-error/render-error';
+import {ReportError} from './components/report-error/report-error';
 import {InfoPanel} from './components/info-panel/info-panel';
 import {UserActions} from './actions/user-actions/user-actions';
 import {NgModuleInfo} from './components/ng-module-info/ng-module-info';
 import {NgModuleConfigView} from './components/ng-module-config-view/ng-module-config-view';
+
+import {UncaughtErrorHandler} from './utils/uncaught-error-handler';
 
 import {
   Connection,
@@ -63,6 +66,7 @@ import {App} from './app';
     PropertyEditor,
     PropertyValue,
     RenderError,
+    ReportError,
     RouterInfo,
     RenderState,
     RouterTree,
@@ -81,6 +85,7 @@ import {App} from './app';
     UserActions,
     ComponentViewState,
     ComponentPropertyState,
+    { provide: ErrorHandler, useClass: UncaughtErrorHandler },
   ],
   bootstrap: [App]
 })

--- a/src/frontend/utils/uncaught-error-handler.ts
+++ b/src/frontend/utils/uncaught-error-handler.ts
@@ -1,0 +1,18 @@
+import {
+  ErrorHandler,
+} from '@angular/core';
+
+export class UncaughtErrorHandler implements ErrorHandler {
+  listeners: Array<(err: Error) => void> = [];
+
+  addListener(listener: (err: Error) => void): () => void {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter(l => l !== listener);
+    };
+  }
+
+  handleError(err: Error): void {
+    this.listeners.forEach(fn => fn(err));
+  }
+}

--- a/src/sentry-connection/sentry-connection.ts
+++ b/src/sentry-connection/sentry-connection.ts
@@ -1,0 +1,19 @@
+import {
+  subscribeToUncaughtExceptions,
+} from '../utils/error-handling';
+
+import * as Raven from 'raven-js';
+
+declare const SENTRY_KEY: string;
+if (SENTRY_KEY && SENTRY_KEY.length > 0) {
+  Raven
+    .config(SENTRY_KEY)
+    .install();
+
+  subscribeToUncaughtExceptions(err => {
+    const e = new Error(err.name);
+    e.message = err.message;
+    e.stack = err.stack;
+    Raven.captureException(e);
+  });
+}

--- a/src/utils/error-handling.ts
+++ b/src/utils/error-handling.ts
@@ -1,0 +1,20 @@
+import {ApplicationError, ApplicationErrorType} from '../communication/application-error';
+import {
+  Message,
+  MessageType,
+  MessageFactory,
+  deserializeMessage,
+} from '../communication';
+
+export const reportUncaughtError = (err: Error) => {
+  chrome.runtime.sendMessage(MessageFactory.sendUncaughtError(err));
+};
+
+export const subscribeToUncaughtExceptions = (fn) => {
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message && message.messageType === MessageType.SendUncaughtError) {
+      deserializeMessage(message);
+      fn(message.content);
+    }
+  });
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = {
     'ng-validate': ['./src/utils/ng-validate'],
     'devtools': ['./src/devtools/devtools'],
     'content-script': ['./src/content-script'],
-    'channel': ['./src/channel/channel']
+    'background': ['./src/channel/channel', './src/sentry-connection/sentry-connection']
   },
 
   // Config for our build files
@@ -113,7 +113,8 @@ module.exports = {
     new DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
       'PRODUCTION': JSON.stringify(process.env.NODE_ENV !== 'development'),
-      'VERSION': JSON.stringify(pkg.version)
+      'VERSION': JSON.stringify(pkg.version),
+      'SENTRY_KEY': JSON.stringify(process.env.SENTRY_KEY),
     }),
     new OccurenceOrderPlugin(),
     new DedupePlugin()


### PR DESCRIPTION
@AbdellaToronto Please review. I will add one or two commits to this for styling of the "send error report" screen, and also maybe a build helper script to ensure you can't make a production build without a `SENTRY_KEY` environment variable.

resolves #955 