### PR TITLE
fix(split-pane): Automatically resize window panes after tab change

### DIFF
--- a/src/frontend/components/app-trees/app-trees.html
+++ b/src/frontend/components/app-trees/app-trees.html
@@ -89,7 +89,7 @@
 </form>
 
 
-<split-pane [ngClass]="{ 'flex-auto flex': selectedTab === Tab.ComponentTree, 'display-none': selectedTab !== Tab.ComponentTree }">
+<split-pane #splitPane [ngClass]="{ 'flex-auto flex': selectedTab === Tab.ComponentTree, 'display-none': selectedTab !== Tab.ComponentTree }">
   <div split-pane-primary-content class="flex flex-column flex-auto">
     <bt-tree-view
        class="flex minheight-100pct"

--- a/src/frontend/components/app-trees/app-trees.ts
+++ b/src/frontend/components/app-trees/app-trees.ts
@@ -48,6 +48,7 @@ export class AppTrees {
   @Output() private tabChange = new EventEmitter<Tab>();
   @Output() private DOMSelectionChange = new EventEmitter<boolean>();
 
+  @ViewChild('splitPane') private splitPane;
   @ViewChild('menuButtonElement') private menuButtonElement;
   @ViewChild('menuElement') private menuElement;
 
@@ -68,6 +69,7 @@ export class AppTrees {
   }];
 
   onTabSelectionChanged(index: number) {
+    this.splitPane.handleTabNavigation();
     this.tabChange.emit(this.tabs[index].tab);
   }
 

--- a/src/frontend/components/split-pane/split-pane.ts
+++ b/src/frontend/components/split-pane/split-pane.ts
@@ -61,6 +61,13 @@ export class SplitPane {
   }
 
   /**
+   * Automatically resize window panes after tab change
+   */
+  handleTabNavigation () {
+    setTimeout(this.windowResized.bind(this));
+  }
+
+  /**
    * Capture the starting mouse position, and set up
    * the mouse move capture div for a resize drag.
    */


### PR DESCRIPTION
Addresses window pane sizing issue after navigating between tabs.
resolves #1026