### PR TITLE
feat(render-state): Make strings/numbers more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "d3": "4.5.0",
     "expose-loader": "0.7.1",
     "immutable": "3.7.6",
+    "jsonschema": "^1.1.1",
     "ramda": "0.24.1",
     "redux": "3.6.0",
     "redux-logger": "3.0.6",

--- a/src/frontend/components/component-info/component-info.ts
+++ b/src/frontend/components/component-info/component-info.ts
@@ -40,9 +40,7 @@ export class ComponentInfo {
   @Output() private updateProperty = new EventEmitter<{path: Path, newValue: any}>();
 
   private changeDetectionStrategies = ChangeDetectionStrategy;
-
   private ComponentLoadState = ComponentLoadState;
-
   private path: Path;
 
   constructor(private actions: UserActions) {}

--- a/src/frontend/components/property-editor/property-editor.html
+++ b/src/frontend/components/property-editor/property-editor.html
@@ -4,6 +4,7 @@
       <span class="editable">
         <span *ngIf="isUndefined()">undefined</span>
         <span *ngIf="isNull()">null</span>
+        <span *ngIf="isNonEmptyString()">"{{value}}"</span>
         <span *ngIf="isEmptyString()">&quot;&quot;</span>
         <span *ngIf="isRenderable()">{{value}}</span>
       </span>

--- a/src/frontend/components/property-editor/property-editor.ts
+++ b/src/frontend/components/property-editor/property-editor.ts
@@ -97,6 +97,10 @@ export class PropertyEditor {
     return this.value === null;
   }
 
+  private isNonEmptyString(): boolean {
+    return !!(typeof this.value === 'string' && this.value.length);
+  }
+
   private isEmptyString(): boolean {
     return typeof this.value === 'string' && this.value.length === 0;
   }
@@ -104,7 +108,8 @@ export class PropertyEditor {
   private isRenderable(): boolean {
     return !this.isUndefined()
         && !this.isNull()
-        && !this.isEmptyString();
+        && !this.isEmptyString()
+        && !this.isNonEmptyString();
   }
 
   private onKeypress(event: KeyboardEvent) {

--- a/src/frontend/components/render-state/render-state.css
+++ b/src/frontend/components/render-state/render-state.css
@@ -21,12 +21,21 @@
 .property-container {
   display: inline-flex;
   white-space: nowrap;
-  width: calc(100% - 15px);
+  position: relative;
 }
 
 .classification {
   width: 100%;
   display: flex;
+}
+
+.set-state-item-undefined {
+  position: absolute;
+  top: -5px; left: 0;
+  font-size: 16px;
+  cursor: pointer;
+  margin-right: 10px;
+  text-decoration: none;
 }
 
 .info-key {

--- a/src/frontend/components/render-state/render-state.html
+++ b/src/frontend/components/render-state/render-state.html
@@ -2,9 +2,11 @@
   <span *ngIf="none">
     No state to show
   </span>
+
+
   <span class="property-container" (click)="expandTree(k, $event)">
-    <span class="info-key" [ngClass]="{output: isEmittable(k)}">
-      <div [ngClass]="{
+    <span class="info-key pl4" [ngClass]="{output: isEmittable(k)}">
+      <div *ngIf="nest(k)" [ngClass]="{
         expander: true,
         rotate90: !expanded(k),
         transparent: !expandable(k)
@@ -30,6 +32,10 @@
         </span>
       </span>
       {{k}}:
+      <a
+        [attr.title]="'Set value to undefined'"
+        class="set-state-item-undefined"
+        (click)="setValueUndefined(k, path.concat(k))">&times;</a>
     </span>
     <span *ngIf="isEmittable(k)" class="emitter">
       <input class="editable" type="text" #prop />

--- a/src/frontend/components/render-state/render-state.ts
+++ b/src/frontend/components/render-state/render-state.ts
@@ -85,6 +85,15 @@ export class RenderState {
     return this.propertyState.expansionState(this.path.concat(key)) === ExpandState.Expanded;
   }
 
+  private setValueUndefined(key: string) {
+    if (typeof this.state[key] === 'undefined') {
+      return;
+    }
+    const path = this.path.slice();
+    const propertyKey = [key];
+    this.updateValue.emit({path, propertyKey, newValue: undefined});
+  }
+
   private displayType(key: string): string {
     const object = this.state[key];
 

--- a/src/styles/components/tab-menu.css
+++ b/src/styles/components/tab-menu.css
@@ -22,6 +22,7 @@
 
 .dark .ngVersion {
   color: #A28AD0;
+}
 
 /* FEEDBACK FORM */
 


### PR DESCRIPTION
Strings are rendered as `"some string"` now in order to prevent confusion between things like: `523` and `"523"`.

A button has also been added for directly setting a value on state to `undefined`.

resolves #1177 