### PR TITLE
[fixes #1209] Single empty root node no longer displays alongside "no routes" message.

### DIFF
--- a/src/frontend/components/router-tree/router-tree.ts
+++ b/src/frontend/components/router-tree/router-tree.ts
@@ -67,7 +67,7 @@ export class RouterTree {
   }
 
   render() {
-    if (!this.routerTree) {
+    if (!this.routerTree || this.routerTree.length === 0) {
       return;
     }
 


### PR DESCRIPTION
Example app with no routes:  

![snip20170814_1](https://user-images.githubusercontent.com/7095609/29281097-acc6a442-80eb-11e7-9715-24814ac514dc.png)

Example app with routes: (same as before) 
![snip20170814_2](https://user-images.githubusercontent.com/7095609/29281114-c2fc1102-80eb-11e7-8a08-75bf667fc183.png)

