### PR TITLE
[Fixes #1218] Added support for viewing / editing component state Map objects.

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -347,6 +347,10 @@ const updateProperty = (tree: MutableTree, path: Path, newValue) => {
   updateNode(tree, path, probed => {
     const instanceParent = getNodeInstanceParent(probed, path);
     if (instanceParent) {
+      const key = path[path.length - 1];
+      if (instanceParent instanceof Map) { // properly handle Map instances
+        instanceParent.set(key, newValue);
+      }
       instanceParent[path[path.length - 1]] = newValue;
     }
   });

--- a/src/frontend/components/render-state/render-state.html
+++ b/src/frontend/components/render-state/render-state.html
@@ -56,7 +56,7 @@
       [id]="id"
       [metadata]="metadata"
       [path]="path.concat(k)"
-      [value]="state[k]"
+      [value]="stateValue(k)"
       (updateValue)="updateValue.emit($event)">
     </bt-state-values>
   </span>
@@ -68,7 +68,7 @@
        [path]="path.concat(k)"
        [componentMetadata]="componentMetadata"
        [metadata]="metadata"
-       [state]="state[k]"
+       [state]="stateValue(k)"
        (updateValue)="updateValue.emit($event)">
     </bt-render-state>
   </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2293,6 +2293,10 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
+jsonschema@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.1.1.tgz#3cede8e3e411d377872eefbc9fdf26383cbc3ed9"
+
 jsprim@^1.2.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.0.tgz#a3b87e40298d8c380552d8cc7628a0bb95a22918"


### PR DESCRIPTION
`Map()` data collections are now expandable and editable. 

![snip20170821_6](https://user-images.githubusercontent.com/7095609/29533565-719dd72e-8680-11e7-9551-432c6756ed83.png)

![snip20170821_7](https://user-images.githubusercontent.com/7095609/29533570-759f4f42-8680-11e7-8acb-924259042dc1.png)
