### PR TITLE
#1344 Add new component metadata resolution for ng v5+

### DIFF
--- a/src/backend/utils/parse-modules.ts
+++ b/src/backend/utils/parse-modules.ts
@@ -1,6 +1,4 @@
-import {classDecorators, componentMetadata} from '../../tree/decorators';
-import {functionName} from '../../utils/function-name';
-import {Route} from '../utils/parse-router';
+import { componentMetadata} from '../../tree/decorators';
 
 export const AUGURY_TOKEN_ID_METADATA_KEY = '__augury_token_id';
 

--- a/src/frontend/components/component-info/component-info.html
+++ b/src/frontend/components/component-info/component-info.html
@@ -17,7 +17,7 @@
   </div>
 
   <div
-    *ngIf="node && node.changeDetection"
+    *ngIf="node && (node.changeDetection !== null && node.changeDetection !== undefined)"
     class="section-title bg-darken-1 bg-panel primary-color pointer border-bottom py2 px3">
     <span class="info-key">Change Detection: </span>{{changeDetectionStrategies[node.changeDetection]}}
   </div>

--- a/src/tree/decorators.ts
+++ b/src/tree/decorators.ts
@@ -7,8 +7,7 @@ import {
 
 import {functionName} from '../utils';
 
-export const classDecorators = (token): Array<any> =>
-  Reflect.getOwnMetadata('annotations', token) || [];
+const ANNOTATIONS_PROP_KEY = '__annotations__';
 
 export const propertyDecorators = (instance): Array<any> =>
   Reflect.getOwnMetadata('propMetadata', instance.constructor) || [];
@@ -42,7 +41,14 @@ export const componentMetadata = (token) => {
     return null;
   }
 
-  return classDecorators(token).find(d => d.toString() === '@Component');
+  // since angular v5 this should work
+  const metadata = (token[ANNOTATIONS_PROP_KEY] || [])
+    .find(d => Object.getPrototypeOf(d).ngMetadataName === 'Component');
+
+  return metadata ? metadata :
+    // Otherwise we fall back to the old way
+    (Reflect.getOwnMetadata('annotations', token) || []).find(d => d.toString() === '@Component');
+
 };
 
 export const componentInputs = (metadata, instance): Array<InputProperty> => {

--- a/src/tree/transformer.ts
+++ b/src/tree/transformer.ts
@@ -18,12 +18,10 @@ import {Path, serializePath} from './path';
 import {functionName, serialize} from '../utils';
 
 import {
-  classDecorators,
   componentMetadata,
   componentInputs,
   componentOutputs,
   parameterTypes,
-  propertyDecorators,
   injectedParameterDecorators,
 } from './decorators';
 


### PR DESCRIPTION
@andrewthauer This fixes: https://github.com/rangle/augury/issues/1344

Starting around angular 5 the component metadata was handled slightly differently. This *should* be fully backwards compatible, but I can't say I have a bunch of older angular apps to test with. How have you been managing that? Can stackblitz be used for older ng versions?