### PR TITLE
fix #1405 Router tree is not scrollable

### DIFF
--- a/src/styles/components/router-tree.css
+++ b/src/styles/components/router-tree.css
@@ -10,6 +10,10 @@ bt-router-tree {
   & .node {
     cursor: pointer;
   }
+  
+  svg {
+    max-height: none;
+  }
 }
 
 .node-route {


### PR DESCRIPTION
fixes #1405 Router tree is not scrollable
Inline CSS: `svg {max-height: 100%; }` being imported from `basscss` is preventing scroll.
Setting `bt-router-tree svg { max-height: none !important; }` enables scroll.